### PR TITLE
fix: update test assertions to match F12 UI changes

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -37,7 +37,7 @@ describe('App routing', () => {
       await screen.findByRole('heading', { name: /choose a training provider/i }),
     ).toBeInTheDocument()
     expect(
-      screen.getByRole('link', { name: /^management$/i }),
+      screen.getByRole('link', { name: /management portal/i }),
     ).toBeInTheDocument()
     expect(screen.queryByRole('link', { name: /^courses$/i })).not.toBeInTheDocument()
   })
@@ -117,7 +117,7 @@ describe('App routing', () => {
     renderRoute('/org/submissions')
 
     expect(
-      await screen.findByRole('heading', { name: /submission review queue/i }),
+      await screen.findByRole('heading', { name: /^submissions$/i }),
     ).toBeInTheDocument()
   })
 
@@ -191,7 +191,7 @@ describe('App routing', () => {
     renderRoute('/org/courses')
 
     expect(
-      await screen.findByRole('heading', { name: /courses are the center of tenant operations/i }),
+      await screen.findByRole('heading', { name: /^courses$/i }),
     ).toBeInTheDocument()
   })
 
@@ -211,7 +211,7 @@ describe('App routing', () => {
       await screen.findByRole('heading', { name: /tenant settings and operational references/i }),
     ).toBeInTheDocument()
     expect(screen.getByRole('link', { name: /^settings$/i })).toHaveClass(
-      'site-header__link--active',
+      'portal-sidebar__item--active',
     )
   })
 
@@ -453,7 +453,7 @@ describe('App routing', () => {
       '/internal',
     )
     expect(screen.getByRole('link', { name: /^tenants$/i })).toHaveClass(
-      'site-header__link--active',
+      'portal-sidebar__item--active',
     )
     expect(screen.getByRole('link', { name: /^users$/i })).toHaveAttribute(
       'href',
@@ -728,7 +728,7 @@ describe('App routing', () => {
       await user.click(screen.getByRole('button', { name: /continue to management/i }))
 
       expect(
-        await screen.findByRole('heading', { name: /courses are the center of tenant operations/i }),
+        await screen.findByRole('heading', { name: /^courses$/i }),
       ).toBeInTheDocument()
     } finally {
       globalThis.fetch = originalFetch

--- a/src/features/enrollment/FormPreview.test.tsx
+++ b/src/features/enrollment/FormPreview.test.tsx
@@ -67,14 +67,14 @@ describe('FormPreview', () => {
 
     await waitFor(() =>
       expect(
-        screen.getByRole('heading', { name: /your enrolment has been submitted/i }),
+        screen.getByRole('heading', { name: /application submitted/i }),
       ).toBeInTheDocument(),
     )
 
     expect(screen.getByText(/intro to ai/i)).toBeInTheDocument()
-    expect(screen.getByRole('link', { name: /review course again/i })).toHaveAttribute(
+    expect(screen.getByRole('link', { name: /back to courses/i })).toHaveAttribute(
       'href',
-      '/acme-training/courses/course-1',
+      '/acme-training/courses',
     )
 
     expect(createEnrollmentMock).toHaveBeenCalledWith(


### PR DESCRIPTION
## Summary

- `App.test.tsx`: updated 6 failing assertions broken by the F12 redesign:
  - Management nav link text changed to "Management portal"
  - Submissions page title changed to "Submissions"
  - Courses page title changed to "Courses" (×2)
  - Active nav class changed from `site-header__link--active` to `portal-sidebar__item--active` (×2)
- `FormPreview.test.tsx`: updated success-state assertions to match F12-04 redesign:
  - Heading changed to "Application submitted"
  - Post-submit link changed to "Back to courses"

These were the tests that caused the CI build failure after PR #68 was merged.

## Test plan

- [x] `npx vitest run` — 92/92 tests pass
- [x] `npx tsc --noEmit` — exits 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)