### PR TITLE
feat(org): tenant portal user management + role redesign + security hardening

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,7 @@
 VITE_API_BASE_URL=https://form-api.kidrawer.com/v1
+# Org/internal routes live on a separate API Gateway after the BS-05 CORS split.
+# Set to the OrgApiBaseUrl SAM output. Omit (or leave blank) to fall back to VITE_API_BASE_URL.
+VITE_ORG_API_BASE_URL=
 VITE_PUBLIC_TENANT_CODES=std-school
 VITE_AUTH_MODE=mock
 VITE_COGNITO_DOMAIN=

--- a/docs/specs/FRONTEND_IMPLEMENTATION_CHECKLIST.md
+++ b/docs/specs/FRONTEND_IMPLEMENTATION_CHECKLIST.md
@@ -95,3 +95,14 @@ Delivered backend-alignment refinements:
 - [ ] F11-06 Responsive, accessibility, and UI polish pass (#46)
 
 Detailed rollout checklist: `docs/specs/PHASE_F11_UI_IMPROVEMENTS.md`
+
+## Security Hardening Phase
+
+- [x] FS-01 Enrollment form field length constraints — `maxLength` on all text inputs, live counter for textareas (#75)
+- [x] FS-02 Friendly 429 rate-limit error state — distinct banner, no retry button (#76)
+- [x] FS-03 Honeypot field on public enrollment form — silently discards bot submissions (#77)
+- [x] FS-04 CAPTCHA widget integration (Cloudflare Turnstile) — blocks submit until token received (#78)
+- [x] FS-05 XSS hygiene — `noopener noreferrer` on all `target="_blank"` links, ESLint rule (#79)
+- [x] FS-06 Dependency vulnerability scanning — `npm audit` in CI, Dependabot weekly (#80)
+
+Detailed rollout checklist: `docs/specs/PHASE_SECURITY_FRONTEND.md`

--- a/docs/specs/FRONTEND_IMPLEMENTATION_CHECKLIST.md
+++ b/docs/specs/FRONTEND_IMPLEMENTATION_CHECKLIST.md
@@ -96,6 +96,15 @@ Delivered backend-alignment refinements:
 
 Detailed rollout checklist: `docs/specs/PHASE_F11_UI_IMPROVEMENTS.md`
 
+## User Management Phase
+
+- [x] FU-01 Org member and invite API functions with correct tenant-scoped paths (#86)
+- [x] FU-02 Users page: member list with remove action and role-based access control (#87)
+- [x] FU-03 Copy invitation link from post-create success state and pending invites table (#88)
+- [ ] FU-04 Invite acceptance page at `/org/accept-invite` (#89)
+
+Detailed rollout checklist: `docs/specs/PHASE_USER_MANAGEMENT_FRONTEND.md`
+
 ## Security Hardening Phase
 
 - [x] FS-01 Enrollment form field length constraints — `maxLength` on all text inputs, live counter for textareas (#75)

--- a/docs/specs/PHASE_ROLE_REDESIGN_FRONTEND.md
+++ b/docs/specs/PHASE_ROLE_REDESIGN_FRONTEND.md
@@ -29,7 +29,7 @@ Implement tasks strictly in order. For each task:
 
 ## Tasks
 
-- [ ] FR-01 Rename `platform_admin` to `platform_support` in all frontend code
+- [x] FR-01 Rename `platform_admin` to `platform_support` in all frontend code
   Issue: https://github.com/bluewuxi/OnlineForms-Frontend/issues/81
   Scope:
   - Find every string literal, type member, and display label that contains `platform_admin`
@@ -51,7 +51,7 @@ Implement tasks strictly in order. For each task:
   - A user session carrying `role: "platform_support"` routes correctly to the internal portal
   - All existing tests pass
 
-- [ ] FR-02 Add `org_viewer` to frontend role types and session handling
+- [x] FR-02 Add `org_viewer` to frontend role types and session handling
   Issue: https://github.com/bluewuxi/OnlineForms-Frontend/issues/82
   Scope:
   - Add `"org_viewer"` to the `AuthRole` (or equivalent) TypeScript union type in `types.ts`
@@ -71,7 +71,7 @@ Implement tasks strictly in order. For each task:
   - `tsc --noEmit` passes
   - All existing tests pass; add a test confirming `org_viewer` satisfies tenant context checks
 
-- [ ] FR-03 Guard org portal write actions behind `org_editor` / `org_admin` role check
+- [x] FR-03 Guard org portal write actions behind `org_editor` / `org_admin` role check
   Issue: https://github.com/bluewuxi/OnlineForms-Frontend/issues/83
   Scope:
   - An `org_viewer` session must not see or be able to trigger any write action in the org
@@ -97,7 +97,7 @@ Implement tasks strictly in order. For each task:
   - `org_editor` and `org_admin` sessions are unaffected — all write actions still appear
   - `useCanWrite` (or equivalent) has a unit test covering all three org roles
 
-- [ ] FR-04 Update invite creation UI to offer `org_viewer` as a role option
+- [x] FR-04 Update invite creation UI to offer `org_viewer` as a role option
   Issue: https://github.com/bluewuxi/OnlineForms-Frontend/issues/84
   Scope:
   - In the invite creation form (wherever `org_admin` can send a member invite), update the
@@ -119,7 +119,7 @@ Implement tasks strictly in order. For each task:
   - Pending-invites list shows `"Org Viewer"` for invites with that role
   - All existing invite flow tests pass; add a test for the `org_viewer` invite path
 
-- [ ] FR-05 Update role display labels across internal portal user management
+- [x] FR-05 Update role display labels across internal portal user management
   Issue: https://github.com/bluewuxi/OnlineForms-Frontend/issues/85
   Scope:
   - The internal portal user management pages (user list, user detail, role add/remove)

--- a/docs/specs/PHASE_ROLE_REDESIGN_FRONTEND.md
+++ b/docs/specs/PHASE_ROLE_REDESIGN_FRONTEND.md
@@ -1,0 +1,164 @@
+# OnlineForms Frontend — Role Redesign Phase
+
+Source: Role design analysis following security hardening phase (FS-01–FS-06). Full
+rationale and agreed design decisions are recorded in the backend repo at
+`docs/reference/role-design.md`. Companion backend phase:
+`OnlineForms/docs/specs/PHASE_ROLE_REDESIGN_BACKEND.md`.
+
+## Goals
+
+- Rename `platform_admin` to `platform_support` in all frontend role types, labels, and guards
+- Add `org_viewer` as a first-class role in session handling, route guards, and UI rendering
+- Hide write-action controls (buttons, forms) from `org_viewer` sessions throughout the org portal
+- Surface the new `org_viewer` role in the invite creation UI
+- Update the session context selector to present `org_viewer` as a valid role choice
+
+## Scope
+
+`src/lib/api/types.ts`, `src/lib/config/env.ts`, `src/features/org-session/`,
+`src/app/routes.tsx`, all org portal page components that render write actions, and the
+invite creation flow. No backend changes are in this phase.
+
+## Workflow Rule
+
+Implement tasks strictly in order. For each task:
+1. Implement feature
+2. Write brief change summary in linked GitHub issue
+3. Update checklist status
+4. Move to next task
+
+## Tasks
+
+- [ ] FR-01 Rename `platform_admin` to `platform_support` in all frontend code
+  Issue: https://github.com/bluewuxi/OnlineForms-Frontend/issues/81
+  Scope:
+  - Find every string literal, type member, and display label that contains `platform_admin`
+    and replace with `platform_support`. Key locations to check:
+    - `src/lib/api/types.ts` — `AuthRole` or equivalent union type
+    - `src/app/routes.tsx` — `allowedRoles` arrays on `RoleProtectedRoute`
+    - `src/features/org-session/` — session validation helpers, `hasInternalCapability`
+      or equivalent guards, portal-detection logic
+    - `src/pages/org/ManagementEntryPage.tsx` — role comparison expressions
+    - `src/pages/internal/` — any display labels showing the role name to the user
+    - Any API response type that carries a `role` field with a `"platform_admin"` literal
+  - Update the `AuthRole` (or `OrgRole`/`SessionRole`) TypeScript type to replace
+    `"platform_admin"` with `"platform_support"` so the compiler catches stale references
+  - Display label: wherever the role is shown to a user (e.g. role badge in the session
+    header or user management table), render `"Platform Support"` instead of `"Platform Admin"`
+  Acceptance:
+  - No string `"platform_admin"` remains in `src/`
+  - TypeScript compiler (`tsc --noEmit`) passes with zero errors
+  - A user session carrying `role: "platform_support"` routes correctly to the internal portal
+  - All existing tests pass
+
+- [ ] FR-02 Add `org_viewer` to frontend role types and session handling
+  Issue: https://github.com/bluewuxi/OnlineForms-Frontend/issues/82
+  Scope:
+  - Add `"org_viewer"` to the `AuthRole` (or equivalent) TypeScript union type in `types.ts`
+  - Update the `OrgProtectedRoute` (or `requiresTenantContext` check) to treat `org_viewer`
+    the same as `org_editor`/`org_admin` — requires a valid `tenantId` to proceed
+  - Update `hasOrgTenantCapability` (or equivalent helper in session utilities) to return
+    `true` for `org_viewer` alongside the other org roles
+  - Update the session context selector (`OrgSessionContextPage` or equivalent) so that
+    when a user has `org_viewer` membership in a tenant, it appears as a selectable context
+    with a clear `"Org Viewer"` label (not `"Org Editor"` or `"Org Admin"`)
+  - The `org_viewer` session context must satisfy the existing session validity checks —
+    `isSessionUsable()` and related guards — without requiring any special casing
+  Acceptance:
+  - A mock session with `role: "org_viewer"` and a valid `tenantId` passes `OrgProtectedRoute`
+    and loads the org portal
+  - The session context selector renders a `"Org Viewer"` option for a user with that membership
+  - `tsc --noEmit` passes
+  - All existing tests pass; add a test confirming `org_viewer` satisfies tenant context checks
+
+- [ ] FR-03 Guard org portal write actions behind `org_editor` / `org_admin` role check
+  Issue: https://github.com/bluewuxi/OnlineForms-Frontend/issues/83
+  Scope:
+  - An `org_viewer` session must not see or be able to trigger any write action in the org
+    portal. Audit every org portal page for write affordances and conditionally hide them
+    based on whether the active role is `org_editor` or `org_admin`. Specific areas:
+    - **Courses list page** — "New Course" button: hide for `org_viewer`
+    - **Course detail / edit page** — "Edit", "Publish", "Archive" buttons: hide for `org_viewer`
+    - **Form schema editor** — entire edit surface: hide / show read-only preview for `org_viewer`
+    - **Submissions list / detail** — "Update Status" action: hide for `org_viewer`
+    - **Branding page** — logo upload control and description editor: hide for `org_viewer`;
+      show current branding values as read-only
+    - **Team / invite page** — "Invite Member" button and form: hide for `org_viewer`
+  - Implement a shared helper hook or utility, e.g. `useCanWrite(): boolean`, that returns
+    `true` only when the active session role is `org_editor` or `org_admin`. Use this hook
+    in every affected page rather than duplicating the role-check inline.
+  - Do not redirect `org_viewer` away from pages — show the page in read-only mode with
+    a brief inline notice where write actions have been removed, e.g.:
+    `"You have read-only access to this tenant. Contact an Org Admin to make changes."`
+  Acceptance:
+  - An `org_viewer` session sees no write buttons across all org portal pages listed above
+  - An `org_viewer` session still loads and reads all data successfully
+  - Read-only notice is visible on at least the Branding and Form Schema pages
+  - `org_editor` and `org_admin` sessions are unaffected — all write actions still appear
+  - `useCanWrite` (or equivalent) has a unit test covering all three org roles
+
+- [ ] FR-04 Update invite creation UI to offer `org_viewer` as a role option
+  Issue: https://github.com/bluewuxi/OnlineForms-Frontend/issues/84
+  Scope:
+  - In the invite creation form (wherever `org_admin` can send a member invite), update the
+    role selector to include `"Org Viewer"` as a valid option alongside `"Org Editor"` and
+    `"Org Admin"`. The value submitted to the API must be the string `"org_viewer"`.
+  - Add a short description beneath each role option in the selector to help admins choose:
+    - Org Viewer — read-only; can browse courses, submissions, and audit history
+    - Org Editor — can create and edit courses, form schemas, and assets
+    - Org Admin — full control; can manage settings, submissions, and team members
+  - Validate on the frontend that the submitted role is one of the three permitted values;
+    show a field error if an unexpected value is present (defensive — the API will also reject)
+  - Update any display in the pending-invites list or member table that shows the invited
+    role to render `"Org Viewer"` correctly for the new value
+  Acceptance:
+  - Invite form role selector contains three options: Org Viewer, Org Editor, Org Admin
+  - Submitting an invite with `org_viewer` role calls `POST /org/tenants/{tenantId}/invites`
+    with `{ role: "org_viewer" }` in the body
+  - Role descriptions are visible in the selector
+  - Pending-invites list shows `"Org Viewer"` for invites with that role
+  - All existing invite flow tests pass; add a test for the `org_viewer` invite path
+
+- [ ] FR-05 Update role display labels across internal portal user management
+  Issue: https://github.com/bluewuxi/OnlineForms-Frontend/issues/85
+  Scope:
+  - The internal portal user management pages (user list, user detail, role add/remove)
+    display role names as labels. Update these to reflect both the rename and the new role:
+    - `"platform_admin"` / `"Platform Admin"` → `"platform_support"` / `"Platform Support"`
+    - Add `"org_viewer"` / `"Org Viewer"` wherever the role label map is defined
+  - Implement or update a centralised role label map, e.g.:
+    ```typescript
+    const ROLE_LABELS: Record<AuthRole, string> = {
+      org_viewer:       "Org Viewer",
+      org_editor:       "Org Editor",
+      org_admin:        "Org Admin",
+      platform_support: "Platform Support",
+      internal_admin:   "Internal Admin",
+    }
+    ```
+    Use this map everywhere a role string is rendered to a human-readable label so future
+    role additions only require updating one place.
+  - Update the role add/remove form in user management to offer `"org_viewer"` and
+    `"platform_support"` (not `"platform_admin"`) in the role selector
+  Acceptance:
+  - No `"Platform Admin"` label appears anywhere in the internal portal UI
+  - `"Platform Support"` is shown correctly in user lists and role badges
+  - `"Org Viewer"` appears in the role selector for user role management
+  - All role names are sourced from the centralised label map
+  - All existing internal portal tests pass
+
+## Status Legend
+
+- `[ ]` Not started
+- `[~]` In progress
+- `[x]` Completed
+
+## Primary References
+
+- `OnlineForms/docs/reference/role-design.md` — full role analysis and agreed design
+- `OnlineForms/docs/specs/PHASE_ROLE_REDESIGN_BACKEND.md` — companion backend phase
+- `src/lib/api/types.ts` — `AuthRole` and session type definitions
+- `src/features/org-session/` — session context, route guards, and portal routing
+- `src/app/routes.tsx` — route definitions and `RoleProtectedRoute` usage
+- `src/pages/org/` — org portal pages with write actions to guard
+- `src/pages/internal/` — internal portal user management pages

--- a/docs/specs/PHASE_SECURITY_FRONTEND.md
+++ b/docs/specs/PHASE_SECURITY_FRONTEND.md
@@ -24,8 +24,8 @@ Implement tasks strictly in order. For each task:
 
 ## Tasks
 
-- [ ] FS-01 Enrollment form field length constraints
-  Issue: https://github.com/bluewuxi/OnlineForms-Frontend/issues/TBD
+- [x] FS-01 Enrollment form field length constraints
+  Issue: https://github.com/bluewuxi/OnlineForms-Frontend/issues/75
   Scope:
   - Add `maxLength` attribute to every `<input type="text">`, `<input type="email">`, and `<textarea>` rendered inside `EnrollmentForm` based on field type:
     - Short text fields: `maxLength={500}`
@@ -39,8 +39,8 @@ Implement tasks strictly in order. For each task:
   - Character counter appears for textarea fields near the limit
   - Exceeding the limit blocks form submission with a clear inline error
 
-- [ ] FS-02 Friendly 429 rate-limit error state
-  Issue: https://github.com/bluewuxi/OnlineForms-Frontend/issues/TBD
+- [x] FS-02 Friendly 429 rate-limit error state
+  Issue: https://github.com/bluewuxi/OnlineForms-Frontend/issues/76
   Scope:
   - The enrollment form submission handler currently shows a generic error banner on API failure
   - Detect HTTP `429 Too Many Requests` responses from `POST /v1/public/{tenantCode}/courses/{courseId}/enrollments` specifically
@@ -54,8 +54,8 @@ Implement tasks strictly in order. For each task:
   - Other `4xx`/`5xx` errors continue to render the existing generic error state
   - No retry button appears on the `429` state
 
-- [ ] FS-03 Honeypot field on enrollment form
-  Issue: https://github.com/bluewuxi/OnlineForms-Frontend/issues/TBD
+- [x] FS-03 Honeypot field on enrollment form
+  Issue: https://github.com/bluewuxi/OnlineForms-Frontend/issues/77
   Scope:
   - Add a hidden honeypot `<input>` field to the enrollment form that is invisible to human users but visible to bots that auto-fill all fields
   - Implementation:
@@ -70,8 +70,8 @@ Implement tasks strictly in order. For each task:
   - Success state is shown to fool bots into thinking submission worked
   - Automated test verifies the honeypot field is present but hidden
 
-- [ ] FS-04 CAPTCHA widget integration (Cloudflare Turnstile)
-  Issue: https://github.com/bluewuxi/OnlineForms-Frontend/issues/TBD
+- [x] FS-04 CAPTCHA widget integration (Cloudflare Turnstile)
+  Issue: https://github.com/bluewuxi/OnlineForms-Frontend/issues/78
   Scope:
   - Integrate Cloudflare Turnstile (invisible mode) into the public enrollment form
   - Why Turnstile: invisible by default (no puzzle), free, privacy-friendly, no Google dependency
@@ -91,8 +91,8 @@ Implement tasks strictly in order. For each task:
   - In test/dev mode (`VITE_TURNSTILE_ENABLED=false`) the form works without a token
   - Existing enrollment form tests continue to pass
 
-- [ ] FS-05 XSS hygiene — external links and rendered content
-  Issue: https://github.com/bluewuxi/OnlineForms-Frontend/issues/TBD
+- [x] FS-05 XSS hygiene — external links and rendered content
+  Issue: https://github.com/bluewuxi/OnlineForms-Frontend/issues/79
   Scope:
   - Audit all `<a target="_blank">` links across the codebase and add `rel="noopener noreferrer"` to prevent tab-napping attacks (the opened page can otherwise access `window.opener` and redirect the parent tab)
   - Audit the `RichText` component — it renders raw HTML via `dangerouslySetInnerHTML`. Verify that all HTML passed to it originates from the backend (trusted source), not from user-submitted content. Add a code comment documenting this trust assumption.
@@ -103,8 +103,8 @@ Implement tasks strictly in order. For each task:
   - `RichText` is documented as trusted-source only
   - ESLint rule is active and CI enforces it
 
-- [ ] FS-06 Dependency vulnerability scanning
-  Issue: https://github.com/bluewuxi/OnlineForms-Frontend/issues/TBD
+- [x] FS-06 Dependency vulnerability scanning
+  Issue: https://github.com/bluewuxi/OnlineForms-Frontend/issues/80
   Scope:
   - Add `npm audit --audit-level=high` to the CI pipeline (GitHub Actions or equivalent) so high/critical CVEs fail the build
   - Enable GitHub Dependabot for the `OnlineForms-Frontend` repository:

--- a/docs/specs/PHASE_SECURITY_FRONTEND.md
+++ b/docs/specs/PHASE_SECURITY_FRONTEND.md
@@ -1,0 +1,129 @@
+# OnlineForms Frontend — Security Hardening Phase
+
+Source: Security review covering public form abuse prevention, input safety, session hygiene, and supply-chain hygiene. Companion backend phase: `OnlineForms/docs/specs/PHASE_SECURITY_BACKEND.md`.
+
+## Goals
+
+- Reduce the attack surface of the public enrollment form against automated abuse
+- Prevent client-side XSS vectors introduced by rendered submission content
+- Enforce field constraints in the UI to complement server-side validation
+- Harden session handling and external link hygiene
+- Establish ongoing dependency vulnerability scanning
+
+## Scope
+
+Frontend-only changes. No new API endpoints are introduced by this phase, though some tasks depend on new backend responses (e.g. `429 Too Many Requests`, CAPTCHA token verification) defined in the backend phase.
+
+## Workflow Rule
+
+Implement tasks strictly in order. For each task:
+1. Implement feature
+2. Write brief change summary in linked GitHub issue
+3. Update checklist status
+4. Move to next task
+
+## Tasks
+
+- [ ] FS-01 Enrollment form field length constraints
+  Issue: https://github.com/bluewuxi/OnlineForms-Frontend/issues/TBD
+  Scope:
+  - Add `maxLength` attribute to every `<input type="text">`, `<input type="email">`, and `<textarea>` rendered inside `EnrollmentForm` based on field type:
+    - Short text fields: `maxLength={500}`
+    - Long text / textarea: `maxLength={5000}`
+    - Email fields: `maxLength={254}` (RFC 5321 maximum)
+  - Add a live character counter hint below textarea fields when content exceeds 80% of the limit, e.g. "420 / 500"
+  - Validate these limits in the client-side submit handler and show an inline field error if exceeded (do not rely solely on the HTML attribute, which can be bypassed)
+  - Ensure the constraints are consistent with whatever the backend enforces (coordinate with FS-03 backend phase)
+  Acceptance:
+  - No enrollment form field accepts more than its defined maximum
+  - Character counter appears for textarea fields near the limit
+  - Exceeding the limit blocks form submission with a clear inline error
+
+- [ ] FS-02 Friendly 429 rate-limit error state
+  Issue: https://github.com/bluewuxi/OnlineForms-Frontend/issues/TBD
+  Scope:
+  - The enrollment form submission handler currently shows a generic error banner on API failure
+  - Detect HTTP `429 Too Many Requests` responses from `POST /v1/public/{tenantCode}/courses/{courseId}/enrollments` specifically
+  - Render a distinct, friendly error state (not the generic red banner) when `429` is received:
+    - Heading: "You've submitted too many applications recently"
+    - Message: "Please wait a while before trying again. If you believe this is an error, contact the training provider."
+    - Do not show a retry button on `429` — instead show the course detail link
+  - This is a frontend concern only; the actual rate limiting is enforced by the backend (see backend phase BS-01)
+  Acceptance:
+  - `429` response renders the specific rate-limit message
+  - Other `4xx`/`5xx` errors continue to render the existing generic error state
+  - No retry button appears on the `429` state
+
+- [ ] FS-03 Honeypot field on enrollment form
+  Issue: https://github.com/bluewuxi/OnlineForms-Frontend/issues/TBD
+  Scope:
+  - Add a hidden honeypot `<input>` field to the enrollment form that is invisible to human users but visible to bots that auto-fill all fields
+  - Implementation:
+    - Add `<input type="text" name="website" tabIndex={-1} autoComplete="off" aria-hidden="true" />` inside the form
+    - Hide it with CSS: `position: absolute; left: -9999px; opacity: 0; height: 0;` — do NOT use `display: none` or `visibility: hidden` as some bots detect these
+    - Give it a plausible name (`website`, `url`, `address2`) to attract bots
+    - In the submit handler, check if the honeypot field has a value; if so, silently pretend the submission succeeded (show the success state) without actually calling the API — do not alert the bot that it was caught
+  - Send the honeypot flag to the backend as a boolean `_hp` field in the submission payload so the backend can also log/reject it (coordinate with backend phase BS-03)
+  Acceptance:
+  - Honeypot field is not visible or tab-reachable by human users
+  - Form submission with honeypot filled never reaches the API
+  - Success state is shown to fool bots into thinking submission worked
+  - Automated test verifies the honeypot field is present but hidden
+
+- [ ] FS-04 CAPTCHA widget integration (Cloudflare Turnstile)
+  Issue: https://github.com/bluewuxi/OnlineForms-Frontend/issues/TBD
+  Scope:
+  - Integrate Cloudflare Turnstile (invisible mode) into the public enrollment form
+  - Why Turnstile: invisible by default (no puzzle), free, privacy-friendly, no Google dependency
+  - Implementation:
+    - Install `@marsidev/react-turnstile` (lightweight React wrapper)
+    - Add `VITE_TURNSTILE_SITE_KEY` environment variable; document in `.env.example`
+    - Render `<Turnstile siteKey={...} onSuccess={(token) => setTurnstileToken(token)} />` inside the enrollment form, hidden below the submit button
+    - Include the `turnstileToken` in the submission payload as `_captchaToken`
+    - If Turnstile fails to load (network error, ad-blocker), degrade gracefully — do not block the form, but log a console warning
+    - Block form submission until a token is obtained; show a subtle loading indicator on the submit button
+    - Backend verifies the token against Cloudflare's API before processing (backend phase BS-02)
+    - Add `VITE_TURNSTILE_ENABLED=true/false` flag so the widget can be disabled in local/test environments without breaking tests
+  Acceptance:
+  - Turnstile widget renders on the enrollment form in production mode
+  - Submit button is disabled until a token is available
+  - `_captchaToken` is included in the submission payload
+  - In test/dev mode (`VITE_TURNSTILE_ENABLED=false`) the form works without a token
+  - Existing enrollment form tests continue to pass
+
+- [ ] FS-05 XSS hygiene — external links and rendered content
+  Issue: https://github.com/bluewuxi/OnlineForms-Frontend/issues/TBD
+  Scope:
+  - Audit all `<a target="_blank">` links across the codebase and add `rel="noopener noreferrer"` to prevent tab-napping attacks (the opened page can otherwise access `window.opener` and redirect the parent tab)
+  - Audit the `RichText` component — it renders raw HTML via `dangerouslySetInnerHTML`. Verify that all HTML passed to it originates from the backend (trusted source), not from user-submitted content. Add a code comment documenting this trust assumption.
+  - If any submission answer is ever rendered via `RichText` or `dangerouslySetInnerHTML`, replace it with a plain text renderer (no HTML interpretation)
+  - Add ESLint rule `react/jsx-no-target-blank` to the lint config to automatically catch future `target="_blank"` without `rel` attributes
+  Acceptance:
+  - All `target="_blank"` links have `rel="noopener noreferrer"`
+  - `RichText` is documented as trusted-source only
+  - ESLint rule is active and CI enforces it
+
+- [ ] FS-06 Dependency vulnerability scanning
+  Issue: https://github.com/bluewuxi/OnlineForms-Frontend/issues/TBD
+  Scope:
+  - Add `npm audit --audit-level=high` to the CI pipeline (GitHub Actions or equivalent) so high/critical CVEs fail the build
+  - Enable GitHub Dependabot for the `OnlineForms-Frontend` repository:
+    - Create `.github/dependabot.yml` with weekly `npm` updates targeting the `master` branch
+    - Group patch updates into a single PR to reduce noise
+  - Resolve any currently open `npm audit` findings of severity `high` or above before closing this task
+  Acceptance:
+  - `npm audit --audit-level=high` exits 0 on current dependencies
+  - Dependabot config file is present and valid
+  - CI pipeline fails on future high/critical CVEs
+
+## Status Legend
+
+- `[ ]` Not started
+- `[~]` In progress
+- `[x]` Completed
+
+## Primary References
+
+- `docs/specs/PHASE_SECURITY_BACKEND.md` (companion backend phase — `OnlineForms` repo)
+- `src/pages/public/CourseDetailPage.tsx` — enrollment form entry point
+- `src/components/content/RichText.tsx` — HTML renderer to audit

--- a/docs/specs/PHASE_USER_MANAGEMENT_FRONTEND.md
+++ b/docs/specs/PHASE_USER_MANAGEMENT_FRONTEND.md
@@ -1,0 +1,110 @@
+# OnlineForms Frontend — Tenant Portal User Management Phase
+
+Source: Backend member management API (commit e97ce6a). Companion backend work is
+already shipped — see `OnlineForms/services/api/src/lib/authMembers.ts` and the
+backend commit for endpoint details.
+
+## Goals
+
+- Allow `org_admin` to view, invite, and remove users who have access to the tenant portal
+- Allow `org_editor` to send invites (but not remove members)
+- Allow `org_viewer` to view the member and invite lists in read-only mode
+- Provide a "Copy invitation link" affordance so invites can be shared manually without
+  relying on system-sent email
+
+## API Contracts
+
+Endpoints introduced by the backend (all under the org API base URL):
+
+| Method   | Path                                          | Auth policy       |
+|----------|-----------------------------------------------|-------------------|
+| `GET`    | `/org/tenants/{tenantId}/members`             | `ORG_MEMBER_READ` |
+| `DELETE` | `/org/tenants/{tenantId}/members/{userId}`    | `ORG_MEMBER_WRITE`|
+| `PATCH`  | `/org/tenants/{tenantId}/members/{userId}`    | `ORG_MEMBER_WRITE`|
+| `GET`    | `/org/tenants/{tenantId}/invites`             | `ORG_MEMBER_READ` |
+| `POST`   | `/org/tenants/{tenantId}/invites`             | `ORG_MEMBER_WRITE`|
+
+`ORG_MEMBER_READ` — accessible by all org roles and `platform_support`.
+`ORG_MEMBER_WRITE` — accessible by `org_admin` only.
+
+Member list response (`GET /members`):
+```json
+{ "data": [ { "userId": "...", "role": "org_admin", "status": "active", "activatedAt": "...", "createdAt": "..." } ] }
+```
+
+Invite list response (`GET /invites`):
+```json
+{ "data": [ { "inviteId": "...", "email": "...", "role": "org_editor", "status": "pending", "createdAt": "...", "expiresAt": "...", "acceptedAt": null } ] }
+```
+
+Backend safety guardrails:
+- Cannot remove the last active `org_admin` → `409 CONFLICT`
+- Cannot remove yourself → `409 CONFLICT`
+- Cannot demote the last active `org_admin` → `409 CONFLICT`
+
+## Tasks
+
+- [x] FU-01 Add org member and invite API functions to `src/lib/api/org.ts`
+  Scope:
+  - `listOrgMembers(session)` → `GET /org/tenants/{tenantId}/members`
+  - `removeOrgMember(session, userId)` → `DELETE /org/tenants/{tenantId}/members/{userId}`
+  - `updateOrgMemberRole(session, userId, role)` → `PATCH /org/tenants/{tenantId}/members/{userId}`
+  - Fix existing `listOrgInvites` path from `/org/invites` → `/org/tenants/{tenantId}/invites`
+  - Fix existing `createOrgInvite` path from `/org/invites` → `/org/tenants/{tenantId}/invites`
+  - Update `OrgMember` type to match backend shape: `{ userId, role, status, activatedAt, createdAt }`
+  - Update `OrgInvite` type to match backend shape: `{ inviteId, email, role, status, createdAt, expiresAt, acceptedAt }`
+  Acceptance:
+  - All new functions call the correct tenant-scoped paths
+  - List responses use `BackendItemEnvelope<T[]>` (non-paginated)
+  - `tsc --noEmit` passes
+
+- [x] FU-02 Rename TeamPage to Users page and add member list with remove action
+  Scope:
+  - Page title changed from "Team" to "Users"
+  - Members section: table showing user ID, role, status, and joined date for all active members
+  - Remove button visible to `org_admin` only; requires inline two-step confirmation
+  - Backend guardrail errors (409) surface gracefully via mutation error state
+  Acceptance:
+  - All three org roles load the members table
+  - `org_viewer` and `org_editor` see no Remove button
+  - `org_admin` sees Remove → Confirm/Cancel flow
+  - Removing the last admin or self shows a graceful error (surfaced from 409 response)
+
+- [x] FU-03 Copy invitation link
+  Scope:
+  - After creating an invite (success state), show the full invite link and a "Copy link" button
+  - Invite link format: `{origin}/org/accept-invite?inviteId={inviteId}`
+  - In the pending invites table, each row has a "Copy link" button (available to all roles)
+  - Button shows "Copied!" for 2 s after clicking, then reverts
+  - Note: the `/org/accept-invite` frontend route and acceptance page are not yet built —
+    the link can be copied now but cannot be followed until FU-04 is implemented
+  Acceptance:
+  - `navigator.clipboard.writeText` is called with the correct URL
+  - "Copied!" feedback appears and clears after 2 s
+  - Button is present on both the post-create success state and each pending invite row
+
+- [ ] FU-04 Invite acceptance page at `/org/accept-invite`
+  Scope:
+  - Public or semi-public route that displays invite details (email, role, tenant)
+  - If user is not authenticated, redirect to Cognito login with returnTo preserved
+  - After login, call `POST /org/tenants/{tenantId}/invites/{inviteId}/accept`
+  - On success, create a session for the new membership and redirect to `/org/submissions`
+  - Handle errors: expired invite, email mismatch, already accepted
+  Acceptance:
+  - An unauthenticated user following the invite link is redirected to login then returned
+  - A matching authenticated user can accept the invite and land in the org portal
+  - Error states are shown for expired, mismatched, and already-accepted invites
+
+## Status Legend
+
+- `[ ]` Not started
+- `[~]` In progress
+- `[x]` Completed
+
+## Primary References
+
+- `OnlineForms/services/api/src/lib/authMembers.ts` — member management business logic
+- `OnlineForms/docs/reference/api-contracts.md` sections 6.5–6.6 — full request/response contracts
+- `src/lib/api/org.ts` — frontend API functions
+- `src/lib/api/types.ts` — `OrgMember`, `OrgInvite`, `OrgRole` types
+- `src/pages/org/TeamPage.tsx` — Users page component

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^5.1.1",
         "eslint": "^9.39.1",
+        "eslint-plugin-react": "^7.37.5",
         "eslint-plugin-react-hooks": "^7.0.1",
         "eslint-plugin-react-refresh": "^0.4.24",
         "globals": "^16.5.0",
@@ -2362,6 +2363,144 @@
         "dequal": "^2.0.3"
       }
     },
+    "node_modules/array-buffer-byte-length": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz",
+      "integrity": "sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "is-array-buffer": "^3.0.5"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array-includes": {
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.9.tgz",
+      "integrity": "sha512-FmeCCAenzH0KH381SPT5FZmiA/TmpndpcaShhfgEN9eCVjnFBqq3l1xrI42y8+PPLI6hypzou4GXw00WHmPBLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.24.0",
+        "es-object-atoms": "^1.1.1",
+        "get-intrinsic": "^1.3.0",
+        "is-string": "^1.1.1",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.findlast": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/array.prototype.findlast/-/array.prototype.findlast-1.2.5.tgz",
+      "integrity": "sha512-CVvd6FHg1Z3POpBLxO6E6zr+rSKEQ9L6rZHAaY7lLfhKsWYUBBOuMs0e9o24oopj6H+geRCX0YJ+TJLBK2eHyQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.2",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
+        "es-shim-unscopables": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.flat": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.3.tgz",
+      "integrity": "sha512-rwG/ja1neyLqCuGZ5YYrznA62D4mZXg0i1cIskIUKSiqF3Cje9/wXAls9B9s1Wa2fomMsIv8czB8jZcPmxCXFg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-shim-unscopables": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.flatmap": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.3.3.tgz",
+      "integrity": "sha512-Y7Wt51eKJSyi80hFrJCePGGNo5ktJCslFuboqJsbf57CCPcm5zztluPlc4/aD8sWsKvlwatezpV4U1efk8kpjg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-shim-unscopables": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.tosorted": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/array.prototype.tosorted/-/array.prototype.tosorted-1.1.4.tgz",
+      "integrity": "sha512-p6Fx8B7b7ZhL/gmUsAy0D15WhvDccw3mnGNbZpi3pmeJdxtWsj2jEaI4Y6oo3XiHfzuSgPwKc04MYt6KgvC/wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.3",
+        "es-errors": "^1.3.0",
+        "es-shim-unscopables": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/arraybuffer.prototype.slice": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.4.tgz",
+      "integrity": "sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-buffer-byte-length": "^1.0.1",
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "is-array-buffer": "^3.0.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -2370,6 +2509,32 @@
       "license": "MIT",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/async-function": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz",
+      "integrity": "sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/available-typed-arrays": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+      "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "possible-typed-array-names": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/balanced-match": {
@@ -2445,6 +2610,56 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/call-bind": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
+      "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.0",
+        "es-define-property": "^1.0.0",
+        "get-intrinsic": "^1.2.4",
+        "set-function-length": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/callsites": {
@@ -2645,6 +2860,60 @@
         "node": ">=20"
       }
     },
+    "node_modules/data-view-buffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.2.tgz",
+      "integrity": "sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/data-view-byte-length": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/data-view-byte-length/-/data-view-byte-length-1.0.2.tgz",
+      "integrity": "sha512-tuhGbE6CfTM9+5ANGf+oQb72Ky/0+s3xKUpHvShfiz2RxMFgFPjsXuRLBVMtvMs15awe45SRb83D6wH4ew6wlQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/inspect-js"
+      }
+    },
+    "node_modules/data-view-byte-offset": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/data-view-byte-offset/-/data-view-byte-offset-1.0.1.tgz",
+      "integrity": "sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -2677,6 +2946,42 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/define-properties": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+      "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.0.1",
+        "has-property-descriptors": "^1.0.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/dequal": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
@@ -2687,6 +2992,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/doctrine": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+      "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "esutils": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/dom-accessibility-api": {
       "version": "0.5.16",
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
@@ -2694,6 +3012,21 @@
       "dev": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.307",
@@ -2715,12 +3048,190 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
+    "node_modules/es-abstract": {
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.24.1.tgz",
+      "integrity": "sha512-zHXBLhP+QehSSbsS9Pt23Gg964240DPd6QCf8WpkqEXxQ7fhdZzYsocOr5u7apWonsS5EjZDmTF+/slGMyasvw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-buffer-byte-length": "^1.0.2",
+        "arraybuffer.prototype.slice": "^1.0.4",
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "data-view-buffer": "^1.0.2",
+        "data-view-byte-length": "^1.0.2",
+        "data-view-byte-offset": "^1.0.1",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "es-set-tostringtag": "^2.1.0",
+        "es-to-primitive": "^1.3.0",
+        "function.prototype.name": "^1.1.8",
+        "get-intrinsic": "^1.3.0",
+        "get-proto": "^1.0.1",
+        "get-symbol-description": "^1.1.0",
+        "globalthis": "^1.0.4",
+        "gopd": "^1.2.0",
+        "has-property-descriptors": "^1.0.2",
+        "has-proto": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "internal-slot": "^1.1.0",
+        "is-array-buffer": "^3.0.5",
+        "is-callable": "^1.2.7",
+        "is-data-view": "^1.0.2",
+        "is-negative-zero": "^2.0.3",
+        "is-regex": "^1.2.1",
+        "is-set": "^2.0.3",
+        "is-shared-array-buffer": "^1.0.4",
+        "is-string": "^1.1.1",
+        "is-typed-array": "^1.1.15",
+        "is-weakref": "^1.1.1",
+        "math-intrinsics": "^1.1.0",
+        "object-inspect": "^1.13.4",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.7",
+        "own-keys": "^1.0.1",
+        "regexp.prototype.flags": "^1.5.4",
+        "safe-array-concat": "^1.1.3",
+        "safe-push-apply": "^1.0.0",
+        "safe-regex-test": "^1.1.0",
+        "set-proto": "^1.0.0",
+        "stop-iteration-iterator": "^1.1.0",
+        "string.prototype.trim": "^1.2.10",
+        "string.prototype.trimend": "^1.0.9",
+        "string.prototype.trimstart": "^1.0.8",
+        "typed-array-buffer": "^1.0.3",
+        "typed-array-byte-length": "^1.0.3",
+        "typed-array-byte-offset": "^1.0.4",
+        "typed-array-length": "^1.0.7",
+        "unbox-primitive": "^1.1.0",
+        "which-typed-array": "^1.1.19"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-iterator-helpers": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/es-iterator-helpers/-/es-iterator-helpers-1.3.1.tgz",
+      "integrity": "sha512-zWwRvqWiuBPr0muUG/78cW3aHROFCNIQ3zpmYDpwdbnt2m+xlNyRWpHBpa2lJjSBit7BQ+RXA1iwbSmu5yJ/EQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.24.1",
+        "es-errors": "^1.3.0",
+        "es-set-tostringtag": "^2.1.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.3.0",
+        "globalthis": "^1.0.4",
+        "gopd": "^1.2.0",
+        "has-property-descriptors": "^1.0.2",
+        "has-proto": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "internal-slot": "^1.1.0",
+        "iterator.prototype": "^1.1.5",
+        "math-intrinsics": "^1.1.0",
+        "safe-array-concat": "^1.1.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/es-module-lexer": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
       "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-shim-unscopables": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/es-shim-unscopables/-/es-shim-unscopables-1.1.0.tgz",
+      "integrity": "sha512-d9T8ucsEhh8Bi1woXCf+TIKDIROLG5WCkxg8geBCbvk22kzwC5G2OnXVMO6FUsvQlgUUXQ2itephWDLqDzbeCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-to-primitive": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.3.0.tgz",
+      "integrity": "sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-callable": "^1.2.7",
+        "is-date-object": "^1.0.5",
+        "is-symbol": "^1.0.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/esbuild": {
       "version": "0.27.3",
@@ -2845,6 +3356,39 @@
         "jiti": {
           "optional": true
         }
+      }
+    },
+    "node_modules/eslint-plugin-react": {
+      "version": "7.37.5",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.37.5.tgz",
+      "integrity": "sha512-Qteup0SqU15kdocexFNAJMvCJEfa2xUKNV4CC1xsVMrIIqEy3SQ/rqyxCWNzfrd3/ldy6HMlD2e0JDVpDg2qIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-includes": "^3.1.8",
+        "array.prototype.findlast": "^1.2.5",
+        "array.prototype.flatmap": "^1.3.3",
+        "array.prototype.tosorted": "^1.1.4",
+        "doctrine": "^2.1.0",
+        "es-iterator-helpers": "^1.2.1",
+        "estraverse": "^5.3.0",
+        "hasown": "^2.0.2",
+        "jsx-ast-utils": "^2.4.1 || ^3.0.0",
+        "minimatch": "^3.1.2",
+        "object.entries": "^1.1.9",
+        "object.fromentries": "^2.0.8",
+        "object.values": "^1.2.1",
+        "prop-types": "^15.8.1",
+        "resolve": "^2.0.0-next.5",
+        "semver": "^6.3.1",
+        "string.prototype.matchall": "^4.0.12",
+        "string.prototype.repeat": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "peerDependencies": {
+        "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7"
       }
     },
     "node_modules/eslint-plugin-react-hooks": {
@@ -3081,6 +3625,22 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/for-each": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
+      "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-callable": "^1.2.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -3096,6 +3656,57 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/function.prototype.name": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.8.tgz",
+      "integrity": "sha512-e5iwyodOHhbMr/yNrc7fDYG4qlbIvI5gajyzPnb5TCwyhjApznQh1BMFou9b30SevY43gCJKXycoCBjMbsuW0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "functions-have-names": "^1.2.3",
+        "hasown": "^2.0.2",
+        "is-callable": "^1.2.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/functions-have-names": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
+      "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/generator-function": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/generator-function/-/generator-function-2.0.1.tgz",
+      "integrity": "sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -3104,6 +3715,63 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-symbol-description": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.1.0.tgz",
+      "integrity": "sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/glob-parent": {
@@ -3132,6 +3800,49 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/globalthis": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
+      "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-properties": "^1.2.1",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-bigints": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
+      "integrity": "sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -3140,6 +3851,77 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-proto": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.2.0.tgz",
+      "integrity": "sha512-KIL7eQPfHQRC8+XluaIw7BHUwwqL19bQn4hzNgdr+1wXoU0KKj6rufu47lhY7KbJR2C6T6+PfyN0Ea7wkSS+qQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/hermes-estree": {
@@ -3247,6 +4029,156 @@
         "node": ">=8"
       }
     },
+    "node_modules/internal-slot": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
+      "integrity": "sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "hasown": "^2.0.2",
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/is-array-buffer": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.5.tgz",
+      "integrity": "sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-async-function": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-async-function/-/is-async-function-2.1.1.tgz",
+      "integrity": "sha512-9dgM/cZBnNvjzaMYHVoxxfPj2QXt22Ev7SuuPrs+xav0ukGB0S6d4ydZdEiM48kLx5kDV+QBPrpVnFyefL8kkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "async-function": "^1.0.0",
+        "call-bound": "^1.0.3",
+        "get-proto": "^1.0.1",
+        "has-tostringtag": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-bigint": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.1.0.tgz",
+      "integrity": "sha512-n4ZT37wG78iz03xPRKJrHTdZbe3IicyucEtdRsV5yglwc3GyUfbAfpSeD0FJ41NbUNSt5wbhqfp1fS+BgnvDFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-bigints": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-boolean-object": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.2.2.tgz",
+      "integrity": "sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-callable": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-core-module": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
+      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-data-view": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-data-view/-/is-data-view-1.0.2.tgz",
+      "integrity": "sha512-RKtWF8pGmS87i2D6gqQu/l7EYRlVdfzemCJN/P3UOs//x1QE7mfhvzHIApBTRf7axvT6DMGwSwBXYCT0nfB9xw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "get-intrinsic": "^1.2.6",
+        "is-typed-array": "^1.1.13"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-date-object": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.1.0.tgz",
+      "integrity": "sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -3255,6 +4187,42 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-finalizationregistry": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-finalizationregistry/-/is-finalizationregistry-1.1.1.tgz",
+      "integrity": "sha512-1pC6N8qWJbWoPtEjgcL2xyhQOP491EQjeUo3qTKcmV8YSDDJrOepfG8pcC7h/QgnQHYSv0mJ3Z/ZWxmatVrysg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-generator-function": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.2.tgz",
+      "integrity": "sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.4",
+        "generator-function": "^2.0.0",
+        "get-proto": "^1.0.1",
+        "has-tostringtag": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-glob": {
@@ -3270,10 +4238,205 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-map": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
+      "integrity": "sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-negative-zero": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.3.tgz",
+      "integrity": "sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-number-object": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.1.1.tgz",
+      "integrity": "sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-potential-custom-element-name": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/is-regex": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
+      "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-set": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.3.tgz",
+      "integrity": "sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-shared-array-buffer": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.4.tgz",
+      "integrity": "sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-string": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.1.1.tgz",
+      "integrity": "sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-symbol": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.1.1.tgz",
+      "integrity": "sha512-9gGx6GTtCQM73BgmHQXfDmLtfjjTUDSyoxTCbp5WtoixAhfgsDirWIcVQ/IHpvI5Vgd5i/J5F7B9cN/WlVbC/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-symbols": "^1.1.0",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-typed-array": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
+      "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "which-typed-array": "^1.1.16"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakmap": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz",
+      "integrity": "sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakref": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.1.1.tgz",
+      "integrity": "sha512-6i9mGWSlqzNMEqpCp93KwRS1uUOodk2OJ6b+sq7ZPDSy2WuI5NFIxp/254TytR8ftefexkWn5xNiHUNpPOfSew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakset": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.4.tgz",
+      "integrity": "sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
       "dev": true,
       "license": "MIT"
     },
@@ -3283,6 +4446,24 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/iterator.prototype": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/iterator.prototype/-/iterator.prototype-1.1.5.tgz",
+      "integrity": "sha512-H0dkQoCa3b2VEeKQBOxFph+JAbcrQdE7KC0UkqwpLmv2EC4P41QXP+rqo9wYodACiG5/WM5s9oDApTU8utwj9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-object-atoms": "^1.0.0",
+        "get-intrinsic": "^1.2.6",
+        "get-proto": "^1.0.0",
+        "has-symbols": "^1.1.0",
+        "set-function-name": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -3391,6 +4572,22 @@
         "node": ">=6"
       }
     },
+    "node_modules/jsx-ast-utils": {
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.5.tgz",
+      "integrity": "sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-includes": "^3.1.6",
+        "array.prototype.flat": "^1.3.1",
+        "object.assign": "^4.1.4",
+        "object.values": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -3438,6 +4635,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -3467,6 +4677,16 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/mdn-data": {
@@ -3532,12 +4752,139 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/node-exports-info": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/node-exports-info/-/node-exports-info-1.6.0.tgz",
+      "integrity": "sha512-pyFS63ptit/P5WqUkt+UUfe+4oevH+bFeIiPPdfb0pFeYEu/1ELnJu5l+5EcTKYL5M7zaAa7S8ddywgXypqKCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array.prototype.flatmap": "^1.3.3",
+        "es-errors": "^1.3.0",
+        "object.entries": "^1.1.9",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/node-releases": {
       "version": "2.0.36",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.36.tgz",
       "integrity": "sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/object.assign": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.7.tgz",
+      "integrity": "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0",
+        "has-symbols": "^1.1.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object.entries": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.9.tgz",
+      "integrity": "sha512-8u/hfXFRBD1O0hPUjioLhoWFHRmt6tKA4/vZPyckBr18l1KE9uHrFaFaUi8MDRTpi4uak2goyPTSNJLXX2k2Hw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/object.fromentries": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.8.tgz",
+      "integrity": "sha512-k6E21FzySsSK5a21KRADBd/NGneRegFO5pLHfdQLpRDETUNJueLXs3WCzyQ3tFRDYgbq3KHGXfTbi2bs8WQ6rQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.2",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object.values": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.2.1.tgz",
+      "integrity": "sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/obug": {
       "version": "2.1.1",
@@ -3566,6 +4913,24 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/own-keys": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.1.tgz",
+      "integrity": "sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-intrinsic": "^1.2.6",
+        "object-keys": "^1.1.1",
+        "safe-push-apply": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/p-limit": {
@@ -3646,6 +5011,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/pathe": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
@@ -3671,6 +5043,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/possible-typed-array-names": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
+      "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/postcss": {
@@ -3741,6 +5123,25 @@
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
+    },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
+    "node_modules/prop-types/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/punycode": {
       "version": "2.3.1",
@@ -3859,6 +5260,50 @@
         "node": ">=8"
       }
     },
+    "node_modules/reflect.getprototypeof": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
+      "integrity": "sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.9",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
+        "get-intrinsic": "^1.2.7",
+        "get-proto": "^1.0.1",
+        "which-builtin-type": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/regexp.prototype.flags": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
+      "integrity": "sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-errors": "^1.3.0",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "set-function-name": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -3867,6 +5312,30 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "2.0.0-next.6",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.6.tgz",
+      "integrity": "sha512-3JmVl5hMGtJ3kMmB3zi3DL25KfkCEyy3Tw7Gmw7z5w8M9WlwoPFnIvwChzu1+cF3iaK3sp18hhPz8ANeimdJfA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.1",
+        "node-exports-info": "^1.6.0",
+        "object-keys": "^1.1.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/resolve-from": {
@@ -3924,6 +5393,61 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/safe-array-concat": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.3.tgz",
+      "integrity": "sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.2",
+        "get-intrinsic": "^1.2.6",
+        "has-symbols": "^1.1.0",
+        "isarray": "^2.0.5"
+      },
+      "engines": {
+        "node": ">=0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/safe-push-apply": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/safe-push-apply/-/safe-push-apply-1.0.0.tgz",
+      "integrity": "sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "isarray": "^2.0.5"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/safe-regex-test": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
+      "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "is-regex": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/saxes": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
@@ -3959,6 +5483,55 @@
       "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
       "license": "MIT"
     },
+    "node_modules/set-function-length": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/set-function-name": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.2.tgz",
+      "integrity": "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "functions-have-names": "^1.2.3",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/set-proto": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/set-proto/-/set-proto-1.0.0.tgz",
+      "integrity": "sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -3980,6 +5553,82 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/siginfo": {
@@ -4012,6 +5661,118 @@
       "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/stop-iteration-iterator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
+      "integrity": "sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "internal-slot": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/string.prototype.matchall": {
+      "version": "4.0.12",
+      "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.12.tgz",
+      "integrity": "sha512-6CC9uyBL+/48dYizRf7H7VAYCMCNTBeM78x/VTUe9bFEaxBepPJDa1Ow99LqI/1yF7kuy7Q3cQsYMrcjGUcskA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.6",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
+        "get-intrinsic": "^1.2.6",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "internal-slot": "^1.1.0",
+        "regexp.prototype.flags": "^1.5.3",
+        "set-function-name": "^2.0.2",
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.repeat": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/string.prototype.repeat/-/string.prototype.repeat-1.0.0.tgz",
+      "integrity": "sha512-0u/TldDbKD8bFCQ/4f5+mNRrXwZ8hg2w7ZR8wa16e8z9XpePWl3eGEcUD0OXpEH/VJH/2G3gjUtR3ZOiBe2S/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.5"
+      }
+    },
+    "node_modules/string.prototype.trim": {
+      "version": "1.2.10",
+      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.10.tgz",
+      "integrity": "sha512-Rs66F0P/1kedk5lyYyH9uBzuiI/kNRmwJAR9quK6VOtIpZ2G+hMZd+HQbbv25MgCA6gEffoMZYxlTod4WcdrKA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.2",
+        "define-data-property": "^1.1.4",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-object-atoms": "^1.0.0",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.trimend": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.9.tgz",
+      "integrity": "sha512-G7Ok5C6E/j4SGfyLCloXTrngQIQU3PWtXGst3yM7Bea9FRURf1S42ZHlZZtsNque2FN2PoUhfZXYLNWwEr4dLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.2",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.trimstart": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.8.tgz",
+      "integrity": "sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/strip-indent": {
       "version": "3.0.0",
@@ -4050,6 +5811,19 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/symbol-tree": {
@@ -4175,6 +5949,84 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/typed-array-buffer": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
+      "integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-typed-array": "^1.1.14"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/typed-array-byte-length": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/typed-array-byte-length/-/typed-array-byte-length-1.0.3.tgz",
+      "integrity": "sha512-BaXgOuIxz8n8pIq3e7Atg/7s+DpiYrxn4vdot3w9KbnBhcRQq6o3xemQdIfynqSeXeDrF32x+WvfzmOjPiY9lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "for-each": "^0.3.3",
+        "gopd": "^1.2.0",
+        "has-proto": "^1.2.0",
+        "is-typed-array": "^1.1.14"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/typed-array-byte-offset": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/typed-array-byte-offset/-/typed-array-byte-offset-1.0.4.tgz",
+      "integrity": "sha512-bTlAFB/FBYMcuX81gbL4OcpH5PmlFHqlCCpAl8AlEzMz5k53oNDvN8p1PNOWLEmI2x4orp3raOFB51tv9X+MFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "for-each": "^0.3.3",
+        "gopd": "^1.2.0",
+        "has-proto": "^1.2.0",
+        "is-typed-array": "^1.1.15",
+        "reflect.getprototypeof": "^1.0.9"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/typed-array-length": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.7.tgz",
+      "integrity": "sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "for-each": "^0.3.3",
+        "gopd": "^1.0.1",
+        "is-typed-array": "^1.1.13",
+        "possible-typed-array-names": "^1.0.0",
+        "reflect.getprototypeof": "^1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -4211,6 +6063,25 @@
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/unbox-primitive": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.1.0.tgz",
+      "integrity": "sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-bigints": "^1.0.2",
+        "has-symbols": "^1.1.0",
+        "which-boxed-primitive": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/undici-types": {
@@ -4475,6 +6346,95 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/which-boxed-primitive": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.1.1.tgz",
+      "integrity": "sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-bigint": "^1.1.0",
+        "is-boolean-object": "^1.2.1",
+        "is-number-object": "^1.1.1",
+        "is-string": "^1.1.1",
+        "is-symbol": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-builtin-type": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/which-builtin-type/-/which-builtin-type-1.2.1.tgz",
+      "integrity": "sha512-6iBczoX+kDQ7a3+YJBnh3T+KZRxM/iYNPXicqk66/Qfm1b93iu+yOImkg0zHbj5LNOcNv1TEADiZ0xa34B4q6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "function.prototype.name": "^1.1.6",
+        "has-tostringtag": "^1.0.2",
+        "is-async-function": "^2.0.0",
+        "is-date-object": "^1.1.0",
+        "is-finalizationregistry": "^1.1.0",
+        "is-generator-function": "^1.0.10",
+        "is-regex": "^1.2.1",
+        "is-weakref": "^1.0.2",
+        "isarray": "^2.0.5",
+        "which-boxed-primitive": "^1.1.0",
+        "which-collection": "^1.0.2",
+        "which-typed-array": "^1.1.16"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-collection": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.2.tgz",
+      "integrity": "sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-map": "^2.0.3",
+        "is-set": "^2.0.3",
+        "is-weakmap": "^2.0.2",
+        "is-weakset": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-typed-array": {
+      "version": "1.1.20",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.20.tgz",
+      "integrity": "sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "for-each": "^0.3.5",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/why-is-node-running": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^5.1.1",
     "eslint": "^9.39.1",
+    "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.4.24",
     "globals": "^16.5.0",

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -460,7 +460,7 @@ describe('App routing', () => {
     )
     expect(screen.queryByRole('link', { name: /^logout$/i })).not.toBeInTheDocument()
     expect(screen.getByRole('button', { name: /demo-user/i })).toBeInTheDocument()
-    expect(screen.getByText(/internal_admin/i)).toBeInTheDocument()
+    expect(screen.getByText(/internal admin/i)).toBeInTheDocument()
 
     const user = userEvent.setup()
     await user.click(screen.getByRole('button', { name: /demo-user/i }))
@@ -480,6 +480,23 @@ describe('App routing', () => {
       'href',
       '/',
     )
+  })
+
+  it('routes org_viewer session to the org portal', async () => {
+    window.localStorage.setItem(
+      ORG_SESSION_STORAGE_KEY,
+      JSON.stringify({
+        userId: 'viewer-user',
+        tenantId: 'tenant-123',
+        role: 'org_viewer',
+      }),
+    )
+
+    renderRoute('/org/submissions')
+
+    expect(
+      await screen.findByRole('heading', { name: /^submissions$/i }),
+    ).toBeInTheDocument()
   })
 
   it('blocks internal tenant route for non-internal roles', async () => {

--- a/src/app/routes.tsx
+++ b/src/app/routes.tsx
@@ -12,6 +12,7 @@ import { CourseEditorPage } from '../pages/org/CourseEditorPage'
 import { CoursesPage } from '../pages/org/CoursesPage'
 import { FormDesignerPage } from '../pages/org/FormDesignerPage'
 import { OrgSettingsPage } from '../pages/org/OrgSettingsPage'
+import { TeamPage } from '../pages/org/TeamPage'
 import { InternalHomePage } from '../pages/internal/InternalHomePage'
 import { InternalLogoutPage } from '../pages/internal/InternalLogoutPage'
 import { InternalTenantsPage } from '../pages/internal/InternalTenantsPage'
@@ -92,7 +93,7 @@ export const appRoutes: RouteObject[] = [
           {
             element: (
               <RoleProtectedRoute
-                allowedRoles={['internal_admin', 'platform_admin']}
+                allowedRoles={['internal_admin', 'platform_support']}
               />
             ),
             children: [
@@ -154,6 +155,10 @@ export const appRoutes: RouteObject[] = [
               {
                 path: 'courses/:courseId/form',
                 element: <FormDesignerPage />,
+              },
+              {
+                path: 'team',
+                element: <TeamPage />,
               },
             ],
           },

--- a/src/components/layout/SiteHeader.tsx
+++ b/src/components/layout/SiteHeader.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from 'react'
 import { NavLink, useNavigate } from 'react-router-dom'
 import { startCognitoLogout } from '../../features/org-session/cognito'
 import { useOrgSession } from '../../features/org-session/useOrgSession'
+import { getRoleLabel } from '../../lib/roleLabels'
 
 type SiteHeaderProps = {
   section: 'public' | 'org' | 'login' | 'internal'
@@ -48,7 +49,7 @@ export function SiteHeader({ section, onMenuToggle }: SiteHeaderProps) {
     !isLikelyGuid(sessionPreferredName) &&
     sessionPreferredName !== sessionLoginName
       ? sessionPreferredName
-      : '') || session?.role || ''
+      : '') || (session?.role ? getRoleLabel(session.role) : '') || ''
 
   useEffect(() => {
     if (!isAccountMenuOpen) {

--- a/src/features/org-session/OrgProtectedRoute.tsx
+++ b/src/features/org-session/OrgProtectedRoute.tsx
@@ -16,7 +16,7 @@ export function OrgProtectedRoute() {
     )
   }
   const requiresTenantContext =
-    session.role === 'org_admin' || session.role === 'org_editor'
+    session.role === 'org_admin' || session.role === 'org_editor' || session.role === 'org_viewer'
   if (requiresTenantContext && (!session.tenantId || session.tenantId.trim().length === 0)) {
     const returnTo = `${location.pathname}${location.search}`
     return (

--- a/src/features/org-session/useCanWrite.test.tsx
+++ b/src/features/org-session/useCanWrite.test.tsx
@@ -1,0 +1,42 @@
+import { renderHook } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { OrgSessionContext, type OrgSessionContextValue } from './OrgSessionReactContext'
+import { useCanWrite } from './useCanWrite'
+
+function makeWrapper(role: string) {
+  const contextValue: OrgSessionContextValue = {
+    session: { userId: 'test-user', tenantId: 'tenant-1', role },
+    signIn: () => undefined,
+    signOut: () => undefined,
+  }
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return (
+      <OrgSessionContext.Provider value={contextValue}>
+        {children}
+      </OrgSessionContext.Provider>
+    )
+  }
+}
+
+describe('useCanWrite', () => {
+  it('returns true for org_admin', () => {
+    const { result } = renderHook(() => useCanWrite(), {
+      wrapper: makeWrapper('org_admin'),
+    })
+    expect(result.current).toBe(true)
+  })
+
+  it('returns true for org_editor', () => {
+    const { result } = renderHook(() => useCanWrite(), {
+      wrapper: makeWrapper('org_editor'),
+    })
+    expect(result.current).toBe(true)
+  })
+
+  it('returns false for org_viewer', () => {
+    const { result } = renderHook(() => useCanWrite(), {
+      wrapper: makeWrapper('org_viewer'),
+    })
+    expect(result.current).toBe(false)
+  })
+})

--- a/src/features/org-session/useCanWrite.ts
+++ b/src/features/org-session/useCanWrite.ts
@@ -1,0 +1,10 @@
+import { useOrgSession } from './useOrgSession'
+
+/**
+ * Returns true when the active session role allows write actions (org_admin or org_editor).
+ * org_viewer sessions get false — use this to conditionally hide write affordances.
+ */
+export function useCanWrite(): boolean {
+  const { session } = useOrgSession()
+  return session?.role === 'org_admin' || session?.role === 'org_editor'
+}

--- a/src/lib/api/http.ts
+++ b/src/lib/api/http.ts
@@ -1,5 +1,5 @@
 import { refreshCognitoSession } from '../../features/org-session/cognito'
-import { getApiBaseUrl, getFrontendCognitoTokenUse } from '../config/env'
+import { getApiBaseUrl, getOrgApiBaseUrl, getFrontendCognitoTokenUse } from '../config/env'
 import {
   notifySessionInvalidated,
   notifySessionRefreshed,
@@ -143,7 +143,9 @@ export async function apiRequest<TResponse>({
   correlationId = createCorrelationId(),
   headers,
 }: ApiRequestOptions): Promise<ApiResult<TResponse>> {
-  const url = joinApiUrl(getApiBaseUrl(), `${path}${buildQueryString(query)}`)
+  const isOrgRoute = path.startsWith('/org/') || path.startsWith('/internal/')
+  const baseUrl = isOrgRoute ? getOrgApiBaseUrl() : getApiBaseUrl()
+  const url = joinApiUrl(baseUrl, `${path}${buildQueryString(query)}`)
   let effectiveSession = session
   if (isCognitoSession(effectiveSession) && isSessionExpiringSoon(effectiveSession)) {
     try {

--- a/src/lib/api/org.ts
+++ b/src/lib/api/org.ts
@@ -809,16 +809,50 @@ export function validateSessionContext(
   }))
 }
 
-export function listOrgInvites(session: OrgSessionHeaders) {
-  return apiRequest<BackendListEnvelope<import('./types').OrgInvite>>({
-    path: '/org/invites',
+export function listOrgMembers(session: OrgSessionHeaders) {
+  return apiRequest<BackendItemEnvelope<import('./types').OrgMember[]>>({
+    path: `/org/tenants/${session.tenantId}/members`,
     session,
   }).then((response) => ({
     ...response,
-    data: {
-      items: response.data.data,
-      nextCursor: response.data.page.nextCursor,
-    },
+    data: response.data.data,
+  }))
+}
+
+export function removeOrgMember(session: OrgSessionHeaders, userId: string) {
+  return apiRequest<BackendItemEnvelope<{ removed: boolean; userId: string }>>({
+    path: `/org/tenants/${session.tenantId}/members/${userId}`,
+    method: 'DELETE',
+    session,
+  }).then((response) => ({
+    ...response,
+    data: response.data.data,
+  }))
+}
+
+export function updateOrgMemberRole(
+  session: OrgSessionHeaders,
+  userId: string,
+  role: import('./types').OrgRole,
+) {
+  return apiRequest<BackendItemEnvelope<import('./types').OrgMember>>({
+    path: `/org/tenants/${session.tenantId}/members/${userId}`,
+    method: 'PATCH',
+    session,
+    body: { role },
+  }).then((response) => ({
+    ...response,
+    data: response.data.data,
+  }))
+}
+
+export function listOrgInvites(session: OrgSessionHeaders) {
+  return apiRequest<BackendItemEnvelope<import('./types').OrgInvite[]>>({
+    path: `/org/tenants/${session.tenantId}/invites`,
+    session,
+  }).then((response) => ({
+    ...response,
+    data: response.data.data,
   }))
 }
 
@@ -827,7 +861,7 @@ export function createOrgInvite(
   payload: import('./types').OrgInvitePayload,
 ) {
   return apiRequest<BackendItemEnvelope<import('./types').OrgInvite>>({
-    path: '/org/invites',
+    path: `/org/tenants/${session.tenantId}/invites`,
     method: 'POST',
     session,
     body: payload,

--- a/src/lib/api/org.ts
+++ b/src/lib/api/org.ts
@@ -808,3 +808,31 @@ export function validateSessionContext(
     data: response.data.data,
   }))
 }
+
+export function listOrgInvites(session: OrgSessionHeaders) {
+  return apiRequest<BackendListEnvelope<import('./types').OrgInvite>>({
+    path: '/org/invites',
+    session,
+  }).then((response) => ({
+    ...response,
+    data: {
+      items: response.data.data,
+      nextCursor: response.data.page.nextCursor,
+    },
+  }))
+}
+
+export function createOrgInvite(
+  session: OrgSessionHeaders,
+  payload: import('./types').OrgInvitePayload,
+) {
+  return apiRequest<BackendItemEnvelope<import('./types').OrgInvite>>({
+    path: '/org/invites',
+    method: 'POST',
+    session,
+    body: payload,
+  }).then((response) => ({
+    ...response,
+    data: response.data.data,
+  }))
+}

--- a/src/lib/api/types.ts
+++ b/src/lib/api/types.ts
@@ -380,7 +380,7 @@ export type InternalUserMembership = {
   roles: string[]
 }
 
-export type InternalRole = 'internal_admin' | 'platform_admin'
+export type InternalRole = 'internal_admin' | 'platform_support'
 
 export type InternalAccessUserDetail = InternalAccessUser & {
   memberships: InternalUserMembership[]
@@ -429,4 +429,30 @@ export type InternalUserActivityEvent = {
 
 export type InternalUserActivityPage = CursorPage<InternalUserActivityEvent> & {
   sourceStatus: 'ok' | 'unavailable'
+}
+
+export type OrgRole = 'org_viewer' | 'org_editor' | 'org_admin'
+
+export type OrgMember = {
+  userId: string
+  email?: string | null
+  preferredName?: string | null
+  role: OrgRole
+  status: 'active' | 'invited' | 'suspended'
+  invitedAt?: string | null
+  joinedAt?: string | null
+}
+
+export type OrgInvitePayload = {
+  email: string
+  role: OrgRole
+}
+
+export type OrgInvite = {
+  inviteId: string
+  email: string
+  role: OrgRole
+  status: 'pending' | 'accepted' | 'expired'
+  invitedAt: string
+  expiresAt?: string | null
 }

--- a/src/lib/api/types.ts
+++ b/src/lib/api/types.ts
@@ -435,12 +435,10 @@ export type OrgRole = 'org_viewer' | 'org_editor' | 'org_admin'
 
 export type OrgMember = {
   userId: string
-  email?: string | null
-  preferredName?: string | null
   role: OrgRole
   status: 'active' | 'invited' | 'suspended'
-  invitedAt?: string | null
-  joinedAt?: string | null
+  activatedAt?: string | null
+  createdAt?: string
 }
 
 export type OrgInvitePayload = {
@@ -452,7 +450,8 @@ export type OrgInvite = {
   inviteId: string
   email: string
   role: OrgRole
-  status: 'pending' | 'accepted' | 'expired'
-  invitedAt: string
+  status: 'pending' | 'accepted'
+  createdAt: string
   expiresAt?: string | null
+  acceptedAt?: string | null
 }

--- a/src/lib/api/types.ts
+++ b/src/lib/api/types.ts
@@ -261,6 +261,9 @@ export type UploadTicketResponse = {
   assetId: string
   uploadUrl: string
   method?: string
+  /** Presigned POST form fields — present when method is POST */
+  fields?: Record<string, string>
+  /** Legacy presigned PUT headers — present when method is PUT */
   headers?: Record<string, string>
   expiresAt?: string
   publicUrl?: string

--- a/src/lib/config/env.ts
+++ b/src/lib/config/env.ts
@@ -15,6 +15,15 @@ export function getApiBaseUrl() {
   return import.meta.env.VITE_API_BASE_URL?.trim() || defaultApiBaseUrl
 }
 
+/**
+ * Base URL for authenticated org/internal routes. After the BS-05 CORS split
+ * these live on a separate API Gateway endpoint. Falls back to the main API
+ * URL so local dev keeps working without the variable set.
+ */
+export function getOrgApiBaseUrl() {
+  return import.meta.env.VITE_ORG_API_BASE_URL?.trim() || getApiBaseUrl()
+}
+
 export function getFallbackTenantCodes(): string[] {
   const raw = import.meta.env.VITE_PUBLIC_TENANT_CODES?.trim()
   if (!raw) {

--- a/src/lib/roleLabels.ts
+++ b/src/lib/roleLabels.ts
@@ -1,0 +1,16 @@
+/**
+ * Centralised human-readable labels for every role string used in this application.
+ * Use this map anywhere a role string is rendered to a user so future role additions
+ * only require updating one place.
+ */
+export const ROLE_LABELS: Record<string, string> = {
+  org_viewer: 'Org Viewer',
+  org_editor: 'Org Editor',
+  org_admin: 'Org Admin',
+  internal_admin: 'Internal Admin',
+  platform_support: 'Platform Support',
+}
+
+export function getRoleLabel(role: string): string {
+  return ROLE_LABELS[role] ?? role
+}

--- a/src/pages/internal/InternalLogoutPage.tsx
+++ b/src/pages/internal/InternalLogoutPage.tsx
@@ -12,7 +12,7 @@ export function InternalLogoutPage() {
 
     async function completeLogout() {
       try {
-        if (session?.accessToken && (session.role === 'internal_admin' || session.role === 'platform_admin')) {
+        if (session?.accessToken && (session.role === 'internal_admin' || session.role === 'platform_support')) {
           await logInternalAccessUserLogout(session)
         }
       } catch {

--- a/src/pages/internal/InternalUsersPage.tsx
+++ b/src/pages/internal/InternalUsersPage.tsx
@@ -8,6 +8,7 @@ import { ListDetailLayout } from '../../components/layout/ListDetailLayout'
 import { PageHero } from '../../components/layout/PageHero'
 import { SectionHeader } from '../../components/layout/SectionHeader'
 import { useOrgSession } from '../../features/org-session/useOrgSession'
+import { getRoleLabel } from '../../lib/roleLabels'
 import {
   activateInternalAccessUser,
   addInternalAccessUserRole,
@@ -475,7 +476,7 @@ export function InternalUsersPage() {
                           <div className="internal-users-role-row">
                               {user.internalRoles.map((role) => (
                                 <StatusChip key={role} tone="info">
-                                  {role}
+                                  {getRoleLabel(role)}
                                 </StatusChip>
                               ))}
                             </div>
@@ -623,7 +624,7 @@ export function InternalUsersPage() {
                         </StatusChip>
                         {selectedUser.internalRoles.map((role) => (
                           <StatusChip key={role} tone="info">
-                            {role}
+                            {getRoleLabel(role)}
                           </StatusChip>
                         ))}
                       </div>
@@ -761,7 +762,7 @@ export function InternalUsersPage() {
                             <li key={membership.tenantId} className="internal-users-memberships__item">
                               <strong>{membership.tenantId}</strong>
                               <span>{membership.status}</span>
-                              <span>{membership.roles.join(', ') || 'No roles'}</span>
+                              <span>{membership.roles.map(getRoleLabel).join(', ') || 'No roles'}</span>
                             </li>
                           ))}
                         </ul>

--- a/src/pages/org/BrandingPage.tsx
+++ b/src/pages/org/BrandingPage.tsx
@@ -6,6 +6,7 @@ import { LoadingState } from '../../components/feedback/LoadingState'
 import { StatusChip } from '../../components/feedback/StatusChip'
 import { PageHero } from '../../components/layout/PageHero'
 import { SectionHeader } from '../../components/layout/SectionHeader'
+import { useCanWrite } from '../../features/org-session/useCanWrite'
 import { useOrgSession } from '../../features/org-session/useOrgSession'
 import {
   ApiClientError,
@@ -47,6 +48,7 @@ async function uploadAssetBinary(ticket: UploadTicketResponse, file: File) {
 
 export function BrandingPage() {
   const { session } = useOrgSession()
+  const canWrite = useCanWrite()
   const [selectedFile, setSelectedFile] = useState<File | null>(null)
   const [uploadedAsset, setUploadedAsset] = useState<OrgAsset | null>(null)
   const [descriptionDraft, setDescriptionDraft] = useState('')
@@ -190,82 +192,95 @@ export function BrandingPage() {
         ) : null}
       </section>
 
-      <section className="content-panel">
-        <SectionHeader
-          eyebrow="Public copy"
-          title="Tenant description"
-          description="This content renders on the public tenant landing page and supports safe HTML authoring with preview."
-        />
-        <form
-          className="session-form"
-          onSubmit={(event) => {
-            event.preventDefault()
-            brandingMutation.mutate({
-              description: effectiveDescriptionDraft.trim() || null,
-              logoAssetId: currentBranding?.logoAssetId ?? null,
-            })
-          }}
-        >
-          <HtmlEditorField
-            label="Tenant description"
-            value={effectiveDescriptionDraft}
-            onChange={(value) => {
-              setDescriptionDirty(true)
-              setDescriptionDraft(value)
-            }}
-          />
-          <div className="session-form__actions">
-            <button
-              className="button button--primary"
-              disabled={brandingMutation.isPending}
-              type="submit"
-            >
-              {brandingMutation.isPending ? 'Saving description...' : 'Save description'}
-            </button>
-            {brandingMutation.isError ? (
-              <p className="session-form__error">
-                Failed to save tenant description.
-              </p>
-            ) : null}
+      {!canWrite ? (
+        <section className="content-panel content-panel--narrow">
+          <div className="designer-banner designer-banner--warning" role="status">
+            <strong>You have read-only access to this tenant.</strong>
+            <span>Contact an Org Admin to make changes.</span>
           </div>
-        </form>
-      </section>
+        </section>
+      ) : null}
 
-      <section className="content-panel">
-        <div className="section-heading">
-          <p className="section-heading__eyebrow">Upload a logo</p>
-          <h2>Request a ticket and upload directly to storage</h2>
-        </div>
-        <div className="branding-grid">
-          <label className="session-form__field">
-            <span>Logo file</span>
-            <input
-              accept="image/png,image/jpeg,image/webp"
-              onChange={(event) =>
-                setSelectedFile(event.target.files?.[0] || null)
-              }
-              type="file"
-            />
-          </label>
-          <div className="branding-grid__actions">
-            <button
-              className="button button--primary"
-              disabled={!selectedFile || uploadMutation.isPending}
-              onClick={() => {
-                if (selectedFile) {
-                  uploadMutation.mutate(selectedFile)
-                }
+      {canWrite ? (
+        <section className="content-panel">
+          <SectionHeader
+            eyebrow="Public copy"
+            title="Tenant description"
+            description="This content renders on the public tenant landing page and supports safe HTML authoring with preview."
+          />
+          <form
+            className="session-form"
+            onSubmit={(event) => {
+              event.preventDefault()
+              brandingMutation.mutate({
+                description: effectiveDescriptionDraft.trim() || null,
+                logoAssetId: currentBranding?.logoAssetId ?? null,
+              })
+            }}
+          >
+            <HtmlEditorField
+              label="Tenant description"
+              value={effectiveDescriptionDraft}
+              onChange={(value) => {
+                setDescriptionDirty(true)
+                setDescriptionDraft(value)
               }}
-              type="button"
-            >
-              {uploadMutation.isPending ? 'Uploading...' : 'Upload logo'}
-            </button>
+            />
+            <div className="session-form__actions">
+              <button
+                className="button button--primary"
+                disabled={brandingMutation.isPending}
+                type="submit"
+              >
+                {brandingMutation.isPending ? 'Saving description...' : 'Save description'}
+              </button>
+              {brandingMutation.isError ? (
+                <p className="session-form__error">
+                  Failed to save tenant description.
+                </p>
+              ) : null}
+            </div>
+          </form>
+        </section>
+      ) : null}
+
+      {canWrite ? (
+        <section className="content-panel">
+          <div className="section-heading">
+            <p className="section-heading__eyebrow">Upload a logo</p>
+            <h2>Request a ticket and upload directly to storage</h2>
           </div>
-        </div>
-        <p className="content-panel__body-copy">
-          Accepted types: PNG, JPEG, or WebP. Maximum size: 5 MB.
-        </p>
-      </section>
+          <div className="branding-grid">
+            <label className="session-form__field">
+              <span>Logo file</span>
+              <input
+                accept="image/png,image/jpeg,image/webp"
+                onChange={(event) =>
+                  setSelectedFile(event.target.files?.[0] || null)
+                }
+                type="file"
+              />
+            </label>
+            <div className="branding-grid__actions">
+              <button
+                className="button button--primary"
+                disabled={!selectedFile || uploadMutation.isPending}
+                onClick={() => {
+                  if (selectedFile) {
+                    uploadMutation.mutate(selectedFile)
+                  }
+                }}
+                type="button"
+              >
+                {uploadMutation.isPending ? 'Uploading...' : 'Upload logo'}
+              </button>
+            </div>
+          </div>
+          <p className="content-panel__body-copy">
+            Accepted types: PNG, JPEG, or WebP. Maximum size: 5 MB.
+          </p>
+        </section>
+      ) : null}
 
       {uploadMutation.isPending ? (
         <LoadingState

--- a/src/pages/org/BrandingPage.tsx
+++ b/src/pages/org/BrandingPage.tsx
@@ -20,11 +20,25 @@ import {
 } from '../../lib/api'
 
 async function uploadAssetBinary(ticket: UploadTicketResponse, file: File) {
-  const response = await fetch(ticket.uploadUrl, {
-    method: ticket.method || 'PUT',
-    headers: ticket.headers,
-    body: file,
-  })
+  let response: Response
+
+  if (ticket.method === 'POST' && ticket.fields) {
+    // Presigned POST — S3 requires a multipart/form-data body.
+    // All policy fields must come before the file, and the file field must be last.
+    const form = new FormData()
+    for (const [key, value] of Object.entries(ticket.fields)) {
+      form.append(key, value)
+    }
+    form.append('file', file)
+    response = await fetch(ticket.uploadUrl, { method: 'POST', body: form })
+  } else {
+    // Presigned PUT (legacy path)
+    response = await fetch(ticket.uploadUrl, {
+      method: 'PUT',
+      headers: ticket.headers,
+      body: file,
+    })
+  }
 
   if (!response.ok) {
     throw new Error(`Upload failed with status ${response.status}.`)

--- a/src/pages/org/CourseEditorPage.tsx
+++ b/src/pages/org/CourseEditorPage.tsx
@@ -5,6 +5,7 @@ import { ErrorState } from '../../components/feedback/ErrorState'
 import { LoadingState } from '../../components/feedback/LoadingState'
 import { HtmlEditorField } from '../../components/forms/HtmlEditorField'
 import { PageHero } from '../../components/layout/PageHero'
+import { useCanWrite } from '../../features/org-session/useCanWrite'
 import { useOrgSession } from '../../features/org-session/useOrgSession'
 import {
   ApiClientError,
@@ -46,6 +47,7 @@ type CourseEditorFormProps = {
   initialDraft: CourseFormState
   isCreateMode: boolean
   session: OrgSessionHeaders
+  canWrite: boolean
 }
 
 const defaultCourseFormState: CourseFormState = {
@@ -138,6 +140,7 @@ function CourseEditorForm({
   initialDraft,
   isCreateMode,
   session,
+  canWrite,
 }: CourseEditorFormProps) {
   const navigate = useNavigate()
   const [draft, setDraft] = useState<CourseFormState>(initialDraft)
@@ -422,7 +425,14 @@ function CourseEditorForm({
           </label>
         ) : null}
 
-        {hasUnsavedChanges ? (
+        {!canWrite ? (
+          <div className="designer-banner designer-banner--warning" role="status">
+            <strong>You have read-only access to this tenant.</strong>
+            <span>Contact an Org Admin to make changes.</span>
+          </div>
+        ) : null}
+
+        {canWrite && hasUnsavedChanges ? (
           <div className="designer-banner designer-banner--warning" role="status">
             <strong>Course draft has unsaved changes.</strong>
             <span>Save the course before moving on to publish or form design tasks.</span>
@@ -438,25 +448,27 @@ function CourseEditorForm({
 
         <div className="course-editor-save-bar">
           <div className="course-editor-save-bar__left">
-            {hasUnsavedChanges ? (
+            {canWrite && hasUnsavedChanges ? (
               <span className="course-editor-save-bar__unsaved">Unsaved changes</span>
             ) : saveMessage ? (
               <span className="course-editor-save-bar__saved">{saveMessage}</span>
             ) : null}
           </div>
           <div className="button-row">
-            <button
-              className="button button--primary"
-              disabled={isSaving || !hasUnsavedChanges}
-              type="submit"
-            >
-              {isSaving
-                ? 'Saving...'
-                : isCreateMode
-                  ? 'Create course'
-                  : 'Save changes'}
-            </button>
-            {!isCreateMode && courseId ? (
+            {canWrite ? (
+              <button
+                className="button button--primary"
+                disabled={isSaving || !hasUnsavedChanges}
+                type="submit"
+              >
+                {isSaving
+                  ? 'Saving...'
+                  : isCreateMode
+                    ? 'Create course'
+                    : 'Save changes'}
+              </button>
+            ) : null}
+            {canWrite && !isCreateMode && courseId ? (
               <>
                 <button
                   className="button button--secondary"
@@ -474,10 +486,12 @@ function CourseEditorForm({
                 >
                   Archive
                 </button>
-                <Link className="button button--ghost" to={`/org/courses/${courseId}/form`}>
-                  Form designer
-                </Link>
               </>
+            ) : null}
+            {!isCreateMode && courseId ? (
+              <Link className="button button--ghost" to={`/org/courses/${courseId}/form`}>
+                Form designer
+              </Link>
             ) : null}
             <Link className="button button--ghost" to="/org/courses">
               Back
@@ -491,6 +505,7 @@ function CourseEditorForm({
 
 export function CourseEditorPage() {
   const { session } = useOrgSession()
+  const canWrite = useCanWrite()
   const { courseId } = useParams()
   const isCreateMode = !courseId || courseId === 'new'
 
@@ -546,6 +561,7 @@ export function CourseEditorPage() {
       {(isCreateMode || (!courseQuery.isLoading && !courseQuery.isError)) && session ? (
         <CourseEditorForm
           key={`${courseId || 'new'}-${courseQuery.data?.updatedAt || 'draft'}`}
+          canWrite={canWrite}
           courseId={courseId}
           initialCourse={courseQuery.data}
           initialDraft={initialDraft}

--- a/src/pages/org/CoursesPage.tsx
+++ b/src/pages/org/CoursesPage.tsx
@@ -7,6 +7,7 @@ import { StatusChip } from '../../components/feedback/StatusChip'
 import { OrgActivityFeed } from '../../components/layout/OrgActivityFeed'
 import { OrgWorkspaceNav } from '../../components/layout/OrgWorkspaceNav'
 import { PageHero } from '../../components/layout/PageHero'
+import { useCanWrite } from '../../features/org-session/useCanWrite'
 import { useOrgSession } from '../../features/org-session/useOrgSession'
 import { listCourses } from '../../lib/api'
 
@@ -50,6 +51,7 @@ function courseStatusTone(
 
 export function CoursesPage() {
   const { session } = useOrgSession()
+  const canWrite = useCanWrite()
   const navigate = useNavigate()
   const coursesQuery = useQuery({
     queryKey: ['org-courses', session?.tenantId],
@@ -86,12 +88,12 @@ export function CoursesPage() {
                 state: 'current',
                 icon: iconCourseList,
               },
-              {
+              ...(canWrite ? [{
                 label: 'Create course',
                 description: 'Start a new course record before moving into form design.',
                 to: '/org/courses/new',
                 icon: iconCreateCourse,
-              },
+              }] : []),
               {
                 label: 'Settings',
                 description: 'Open tenant branding and audit tools.',
@@ -123,11 +125,13 @@ export function CoursesPage() {
                     <p className="section-heading__eyebrow">Course list</p>
                     <h2>{coursesQuery.data.items.length} course{coursesQuery.data.items.length !== 1 ? 's' : ''}</h2>
                   </div>
-                  <div className="section-header__actions">
-                    <Link className="button button--primary" to="/org/courses/new">
-                      Create course
-                    </Link>
-                  </div>
+                  {canWrite ? (
+                    <div className="section-header__actions">
+                      <Link className="button button--primary" to="/org/courses/new">
+                        Create course
+                      </Link>
+                    </div>
+                  ) : null}
                 </div>
 
                 <div className="org-course-card-grid">
@@ -183,9 +187,11 @@ export function CoursesPage() {
             ) : (
               <EmptyState
                 title="No courses yet"
-                message="Create the first course to begin the publishing and enrollment workflow."
-                actionLabel="Create course"
-                onAction={() => navigate('/org/courses/new')}
+                message={canWrite
+                  ? 'Create the first course to begin the publishing and enrollment workflow.'
+                  : 'No courses have been created for this tenant yet.'}
+                actionLabel={canWrite ? 'Create course' : undefined}
+                onAction={canWrite ? () => navigate('/org/courses/new') : undefined}
               />
             )
           ) : null}

--- a/src/pages/org/FormDesignerPage.tsx
+++ b/src/pages/org/FormDesignerPage.tsx
@@ -5,6 +5,7 @@ import { ErrorState } from '../../components/feedback/ErrorState'
 import { LoadingState } from '../../components/feedback/LoadingState'
 import { PageHero } from '../../components/layout/PageHero'
 import { buildFormSchemaUpsertPayload } from '../../features/form-designer/schemaPayload'
+import { useCanWrite } from '../../features/org-session/useCanWrite'
 import { useOrgSession } from '../../features/org-session/useOrgSession'
 import {
   ApiClientError,
@@ -116,6 +117,7 @@ function createInitialEnrollmentFields(): FormField[] {
 }
 
 type FormDesignerEditorProps = {
+  canWrite: boolean
   courseId: string
   formId?: string
   isNewSchema?: boolean
@@ -126,6 +128,7 @@ type FormDesignerEditorProps = {
 }
 
 function FormDesignerEditor({
+  canWrite,
   courseId,
   formId,
   isNewSchema = false,
@@ -303,36 +306,44 @@ function FormDesignerEditor({
             <p className="section-heading__eyebrow">Field list</p>
             <h2>Editor fields</h2>
           </div>
-          <div className="button-row">
-            <button className="button button--primary" onClick={addField} type="button">
-              Add field
-            </button>
-            <button
-              className="button button--ghost"
-              disabled={!selectedField}
-              onClick={() => moveSelectedField('up')}
-              type="button"
-            >
-              Move up
-            </button>
-            <button
-              className="button button--ghost"
-              disabled={!selectedField}
-              onClick={() => moveSelectedField('down')}
-              type="button"
-            >
-              Move down
-            </button>
-            <button
-              className="button button--secondary"
-              disabled={!editableFields.length || !hasUnsavedChanges || saveMutation.isPending}
-              onClick={() => saveMutation.mutate()}
-              type="button"
-            >
-              {saveMutation.isPending ? 'Saving schema...' : 'Save schema'}
-            </button>
-          </div>
-          {hasUnsavedChanges ? (
+          {!canWrite ? (
+            <div className="designer-banner designer-banner--warning" role="status">
+              <strong>You have read-only access to this tenant.</strong>
+              <span>Contact an Org Admin to make changes.</span>
+            </div>
+          ) : null}
+          {canWrite ? (
+            <div className="button-row">
+              <button className="button button--primary" onClick={addField} type="button">
+                Add field
+              </button>
+              <button
+                className="button button--ghost"
+                disabled={!selectedField}
+                onClick={() => moveSelectedField('up')}
+                type="button"
+              >
+                Move up
+              </button>
+              <button
+                className="button button--ghost"
+                disabled={!selectedField}
+                onClick={() => moveSelectedField('down')}
+                type="button"
+              >
+                Move down
+              </button>
+              <button
+                className="button button--secondary"
+                disabled={!editableFields.length || !hasUnsavedChanges || saveMutation.isPending}
+                onClick={() => saveMutation.mutate()}
+                type="button"
+              >
+                {saveMutation.isPending ? 'Saving schema...' : 'Save schema'}
+              </button>
+            </div>
+          ) : null}
+          {canWrite && hasUnsavedChanges ? (
             <div className="designer-banner designer-banner--warning" role="status">
               <strong>Draft has unsaved changes.</strong>
               <span>Save the schema to publish the next form version for this course.</span>
@@ -393,7 +404,7 @@ function FormDesignerEditor({
           )}
         </section>
 
-        <section className="content-panel">
+        {canWrite ? (<section className="content-panel">
           <div className="section-heading">
             <p className="section-heading__eyebrow">Field editor</p>
             <h2>Core field properties</h2>
@@ -628,7 +639,7 @@ function FormDesignerEditor({
               </p>
             </div>
           )}
-        </section>
+        </section>) : null}
       </section>
     </>
   )
@@ -644,6 +655,7 @@ function createEmptyFormSchema(courseId: string): FormSchema {
 
 export function FormDesignerPage() {
   const { session } = useOrgSession()
+  const canWrite = useCanWrite()
   const { courseId = '' } = useParams()
   const schemaQuery = useQuery({
     queryKey: ['org-form-schema', session?.tenantId, courseId],
@@ -697,6 +709,7 @@ export function FormDesignerPage() {
       {!schemaQuery.isLoading && !schemaQuery.isError && session ? (
         <FormDesignerEditor
           key={`${schemaQuery.data?.schema.id || 'draft'}-${schemaQuery.data?.schema.version || 0}-${courseId}`}
+          canWrite={canWrite}
           courseId={schemaQuery.data?.schema.courseId || courseId}
           formId={schemaQuery.data?.schema.id}
           initialFields={schemaQuery.data?.schema.fields ?? []}

--- a/src/pages/org/ManagementEntryPage.tsx
+++ b/src/pages/org/ManagementEntryPage.tsx
@@ -8,12 +8,12 @@ import {
 import { useOrgSession } from '../../features/org-session/useOrgSession'
 
 function hasInternalCapability(role: string) {
-  return role === 'internal_admin' || role === 'platform_admin'
+  return role === 'internal_admin' || role === 'platform_support'
 }
 
 function hasOrgTenantCapability(role: string, tenantId?: string) {
   return (
-    (role === 'org_admin' || role === 'org_editor') &&
+    (role === 'org_admin' || role === 'org_editor' || role === 'org_viewer') &&
     Boolean(tenantId && tenantId.trim().length > 0)
   )
 }

--- a/src/pages/org/OrgLoginPage.tsx
+++ b/src/pages/org/OrgLoginPage.tsx
@@ -30,14 +30,23 @@ type OrgLoginFormValues = {
 }
 
 const fallbackRoles: AuthRoleOption[] = [
+  { role: 'org_viewer', label: 'Org Viewer', requiresTenant: true },
   { role: 'org_admin', label: 'Org Admin', requiresTenant: true },
   { role: 'org_editor', label: 'Org Editor', requiresTenant: true },
   { role: 'internal_admin', label: 'Internal Admin', requiresTenant: false },
-  { role: 'platform_admin', label: 'Platform Admin', requiresTenant: true },
+  { role: 'platform_support', label: 'Platform Support', requiresTenant: true },
 ]
 
+const ROLE_LABELS: Record<string, string> = {
+  org_viewer: 'Org Viewer',
+  org_editor: 'Org Editor',
+  org_admin: 'Org Admin',
+  internal_admin: 'Internal Admin',
+  platform_support: 'Platform Support',
+}
+
 function hasInternalCapability(role: string | null | undefined) {
-  return role === 'internal_admin' || role === 'platform_admin'
+  return role === 'internal_admin' || role === 'platform_support'
 }
 
 export function OrgLoginPage() {
@@ -417,7 +426,7 @@ export function OrgLoginPage() {
                     <option value="">Select role</option>
                     {cognitoTenantRoleOptions.map((role) => (
                       <option key={role} value={role}>
-                        {role}
+                        {ROLE_LABELS[role] ?? role}
                       </option>
                     ))}
                   </select>

--- a/src/pages/org/SubmissionDetailPage.tsx
+++ b/src/pages/org/SubmissionDetailPage.tsx
@@ -4,6 +4,7 @@ import { ErrorState } from '../../components/feedback/ErrorState'
 import { LoadingState } from '../../components/feedback/LoadingState'
 import { StatusChip } from '../../components/feedback/StatusChip'
 import { PageHero } from '../../components/layout/PageHero'
+import { useCanWrite } from '../../features/org-session/useCanWrite'
 import { useOrgSession } from '../../features/org-session/useOrgSession'
 import {
   ApiClientError,
@@ -45,6 +46,7 @@ function extractApplicantSummary(submission: Submission) {
 
 export function SubmissionDetailPage() {
   const { session } = useOrgSession()
+  const canWrite = useCanWrite()
   const { submissionId = '' } = useParams()
   const queryClient = useQueryClient()
   const submissionQuery = useQuery({
@@ -226,24 +228,26 @@ export function SubmissionDetailPage() {
                 {submission.status}
               </StatusChip>
             </div>
-            <div className="button-row">
-              <button
-                className="button button--primary"
-                disabled={submission.status !== 'submitted' || updateMutation.isPending}
-                onClick={() => updateMutation.mutate({ status: 'reviewed' })}
-                type="button"
-              >
-                {updateMutation.isPending ? 'Updating...' : 'Mark reviewed'}
-              </button>
-              <button
-                className="button button--ghost"
-                disabled={submission.status !== 'submitted' || updateMutation.isPending}
-                onClick={() => updateMutation.mutate({ status: 'canceled' })}
-                type="button"
-              >
-                Mark canceled
-              </button>
-            </div>
+            {canWrite ? (
+              <div className="button-row">
+                <button
+                  className="button button--primary"
+                  disabled={submission.status !== 'submitted' || updateMutation.isPending}
+                  onClick={() => updateMutation.mutate({ status: 'reviewed' })}
+                  type="button"
+                >
+                  {updateMutation.isPending ? 'Updating...' : 'Mark reviewed'}
+                </button>
+                <button
+                  className="button button--ghost"
+                  disabled={submission.status !== 'submitted' || updateMutation.isPending}
+                  onClick={() => updateMutation.mutate({ status: 'canceled' })}
+                  type="button"
+                >
+                  Mark canceled
+                </button>
+              </div>
+            ) : null}
             {updateMutation.isError ? (
               <p className="submission-action-bar__error" role="alert">
                 {updateMutation.error.message}

--- a/src/pages/org/TeamPage.tsx
+++ b/src/pages/org/TeamPage.tsx
@@ -1,0 +1,252 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { useState } from 'react'
+import { EmptyState } from '../../components/feedback/EmptyState'
+import { ErrorState } from '../../components/feedback/ErrorState'
+import { LoadingState } from '../../components/feedback/LoadingState'
+import { StatusChip } from '../../components/feedback/StatusChip'
+import { PageHero } from '../../components/layout/PageHero'
+import { SectionHeader } from '../../components/layout/SectionHeader'
+import { useCanWrite } from '../../features/org-session/useCanWrite'
+import { useOrgSession } from '../../features/org-session/useOrgSession'
+import { ApiClientError, createOrgInvite, listOrgInvites, type OrgInvite, type OrgRole } from '../../lib/api'
+
+type InviteFormState = {
+  email: string
+  role: OrgRole
+}
+
+const ROLE_OPTIONS: Array<{ value: OrgRole; label: string; description: string }> = [
+  {
+    value: 'org_viewer',
+    label: 'Org Viewer',
+    description: 'Read-only; can browse courses, submissions, and audit history.',
+  },
+  {
+    value: 'org_editor',
+    label: 'Org Editor',
+    description: 'Can create and edit courses, form schemas, and assets.',
+  },
+  {
+    value: 'org_admin',
+    label: 'Org Admin',
+    description: 'Full control; can manage settings, submissions, and team members.',
+  },
+]
+
+const VALID_ROLES: OrgRole[] = ['org_viewer', 'org_editor', 'org_admin']
+
+function inviteStatusTone(status: OrgInvite['status']): 'info' | 'success' | 'muted' {
+  if (status === 'pending') return 'info'
+  if (status === 'accepted') return 'success'
+  return 'muted'
+}
+
+function formatInviteDate(value?: string | null) {
+  if (!value) return '—'
+  const date = new Date(value)
+  return Number.isNaN(date.getTime()) ? value : date.toLocaleDateString()
+}
+
+const ROLE_LABELS: Record<OrgRole, string> = {
+  org_viewer: 'Org Viewer',
+  org_editor: 'Org Editor',
+  org_admin: 'Org Admin',
+}
+
+export function TeamPage() {
+  const { session } = useOrgSession()
+  const canWrite = useCanWrite()
+  const queryClient = useQueryClient()
+  const [inviteForm, setInviteForm] = useState<InviteFormState>({
+    email: '',
+    role: 'org_editor',
+  })
+  const [formError, setFormError] = useState<string | null>(null)
+  const [successMessage, setSuccessMessage] = useState<string | null>(null)
+
+  const invitesQuery = useQuery({
+    queryKey: ['org-invites', session?.tenantId],
+    queryFn: async () => {
+      if (!session) return { items: [], nextCursor: null }
+      const response = await listOrgInvites(session)
+      return response.data
+    },
+    enabled: Boolean(session),
+  })
+
+  const createInviteMutation = useMutation({
+    mutationFn: async () => {
+      if (!session) throw new Error('Missing org session.')
+      if (!VALID_ROLES.includes(inviteForm.role)) {
+        throw new Error('Invalid role selected.')
+      }
+      const response = await createOrgInvite(session, {
+        email: inviteForm.email.trim(),
+        role: inviteForm.role,
+      })
+      return response.data
+    },
+    onMutate: () => {
+      setFormError(null)
+      setSuccessMessage(null)
+    },
+    onSuccess: (invite) => {
+      setInviteForm({ email: '', role: 'org_editor' })
+      setSuccessMessage(`Invite sent to ${invite.email} as ${ROLE_LABELS[invite.role]}.`)
+      void queryClient.invalidateQueries({ queryKey: ['org-invites', session?.tenantId] })
+    },
+    onError: (error) => {
+      setFormError(error instanceof ApiClientError ? error.message : 'Failed to send invite.')
+    },
+  })
+
+  function handleSubmit(event: React.FormEvent) {
+    event.preventDefault()
+    if (!inviteForm.email.trim()) {
+      setFormError('Email is required.')
+      return
+    }
+    if (!VALID_ROLES.includes(inviteForm.role)) {
+      setFormError('Select a valid role.')
+      return
+    }
+    createInviteMutation.mutate()
+  }
+
+  return (
+    <div className="page-stack">
+      <PageHero
+        badge="Org portal"
+        title="Team"
+        description="Manage team membership and invite new members to access this tenant."
+      />
+
+      {canWrite ? (
+        <section className="content-panel content-panel--narrow">
+          <SectionHeader
+            eyebrow="Invite"
+            title="Invite a team member"
+            description="Sent invites are valid for 7 days. The recipient must register or sign in to accept."
+          />
+          <form className="session-form" onSubmit={handleSubmit}>
+            <label className="session-form__field">
+              <span>Email address</span>
+              <input
+                type="email"
+                value={inviteForm.email}
+                onChange={(event) => {
+                  setFormError(null)
+                  setInviteForm((current) => ({ ...current, email: event.target.value }))
+                }}
+                placeholder="member@example.com"
+                autoComplete="off"
+              />
+            </label>
+            <label className="session-form__field">
+              <span>Role</span>
+              <select
+                value={inviteForm.role}
+                onChange={(event) => {
+                  setFormError(null)
+                  setInviteForm((current) => ({ ...current, role: event.target.value as OrgRole }))
+                }}
+              >
+                {ROLE_OPTIONS.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+            </label>
+            {ROLE_OPTIONS.find((o) => o.value === inviteForm.role) ? (
+              <p className="content-panel__body-copy">
+                {ROLE_OPTIONS.find((o) => o.value === inviteForm.role)!.description}
+              </p>
+            ) : null}
+            <div className="session-form__actions">
+              <button
+                className="button button--primary"
+                type="submit"
+                disabled={createInviteMutation.isPending}
+              >
+                {createInviteMutation.isPending ? 'Sending...' : 'Send invite'}
+              </button>
+            </div>
+            {formError ? (
+              <p className="session-form__error">{formError}</p>
+            ) : null}
+            {successMessage ? (
+              <p className="content-panel__body-copy">{successMessage}</p>
+            ) : null}
+          </form>
+        </section>
+      ) : (
+        <section className="content-panel content-panel--narrow">
+          <div className="designer-banner designer-banner--warning" role="status">
+            <strong>You have read-only access to this tenant.</strong>
+            <span>Contact an Org Admin to make changes.</span>
+          </div>
+        </section>
+      )}
+
+      <section className="content-panel">
+        <SectionHeader
+          eyebrow="Pending invites"
+          title="Sent invites"
+          description="Invites waiting for the recipient to accept."
+        />
+
+        {invitesQuery.isLoading ? (
+          <LoadingState
+            title="Loading invites"
+            message="Fetching pending invites for this tenant."
+          />
+        ) : null}
+
+        {invitesQuery.isError ? (
+          <ErrorState
+            title="Could not load invites"
+            message="The invites request failed. Check the org session or retry."
+            onRetry={() => void invitesQuery.refetch()}
+          />
+        ) : null}
+
+        {!invitesQuery.isLoading && !invitesQuery.isError ? (
+          invitesQuery.data?.items.length ? (
+            <div className="responsive-table">
+              <table className="data-table">
+                <thead>
+                  <tr>
+                    <th scope="col">Email</th>
+                    <th scope="col">Role</th>
+                    <th scope="col">Status</th>
+                    <th scope="col">Invited</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {invitesQuery.data.items.map((invite) => (
+                    <tr key={invite.inviteId}>
+                      <td>{invite.email}</td>
+                      <td>{ROLE_LABELS[invite.role]}</td>
+                      <td>
+                        <StatusChip tone={inviteStatusTone(invite.status)}>
+                          {invite.status}
+                        </StatusChip>
+                      </td>
+                      <td>{formatInviteDate(invite.invitedAt)}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          ) : (
+            <EmptyState
+              title="No pending invites"
+              message="Invites sent to team members will appear here."
+            />
+          )
+        ) : null}
+      </section>
+    </div>
+  )
+}

--- a/src/pages/org/TeamPage.tsx
+++ b/src/pages/org/TeamPage.tsx
@@ -1,5 +1,5 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
-import { useState } from 'react'
+import { useCallback, useState } from 'react'
 import { EmptyState } from '../../components/feedback/EmptyState'
 import { ErrorState } from '../../components/feedback/ErrorState'
 import { LoadingState } from '../../components/feedback/LoadingState'
@@ -8,7 +8,16 @@ import { PageHero } from '../../components/layout/PageHero'
 import { SectionHeader } from '../../components/layout/SectionHeader'
 import { useCanWrite } from '../../features/org-session/useCanWrite'
 import { useOrgSession } from '../../features/org-session/useOrgSession'
-import { ApiClientError, createOrgInvite, listOrgInvites, type OrgInvite, type OrgRole } from '../../lib/api'
+import {
+  ApiClientError,
+  createOrgInvite,
+  listOrgInvites,
+  listOrgMembers,
+  removeOrgMember,
+  type OrgInvite,
+  type OrgMember,
+  type OrgRole,
+} from '../../lib/api'
 
 type InviteFormState = {
   email: string
@@ -35,39 +44,60 @@ const ROLE_OPTIONS: Array<{ value: OrgRole; label: string; description: string }
 
 const VALID_ROLES: OrgRole[] = ['org_viewer', 'org_editor', 'org_admin']
 
-function inviteStatusTone(status: OrgInvite['status']): 'info' | 'success' | 'muted' {
-  if (status === 'pending') return 'info'
-  if (status === 'accepted') return 'success'
-  return 'muted'
-}
-
-function formatInviteDate(value?: string | null) {
-  if (!value) return '—'
-  const date = new Date(value)
-  return Number.isNaN(date.getTime()) ? value : date.toLocaleDateString()
-}
-
 const ROLE_LABELS: Record<OrgRole, string> = {
   org_viewer: 'Org Viewer',
   org_editor: 'Org Editor',
   org_admin: 'Org Admin',
 }
 
+function memberStatusTone(status: OrgMember['status']): 'success' | 'info' | 'muted' {
+  if (status === 'active') return 'success'
+  if (status === 'invited') return 'info'
+  return 'muted'
+}
+
+function inviteStatusTone(status: OrgInvite['status']): 'info' | 'success' {
+  return status === 'pending' ? 'info' : 'success'
+}
+
+function formatDate(value?: string | null) {
+  if (!value) return '—'
+  const date = new Date(value)
+  return Number.isNaN(date.getTime()) ? value : date.toLocaleDateString()
+}
+
+function buildInviteLink(inviteId: string) {
+  return `${window.location.origin}/org/accept-invite?inviteId=${encodeURIComponent(inviteId)}`
+}
+
 export function TeamPage() {
   const { session } = useOrgSession()
   const canWrite = useCanWrite()
+  const isAdmin = session?.role === 'org_admin'
   const queryClient = useQueryClient()
-  const [inviteForm, setInviteForm] = useState<InviteFormState>({
-    email: '',
-    role: 'org_editor',
-  })
+
+  const [inviteForm, setInviteForm] = useState<InviteFormState>({ email: '', role: 'org_editor' })
   const [formError, setFormError] = useState<string | null>(null)
   const [successMessage, setSuccessMessage] = useState<string | null>(null)
+  const [lastCreatedInvite, setLastCreatedInvite] = useState<OrgInvite | null>(null)
+
+  const [pendingRemoveUserId, setPendingRemoveUserId] = useState<string | null>(null)
+  const [copiedInviteId, setCopiedInviteId] = useState<string | null>(null)
+
+  const membersQuery = useQuery({
+    queryKey: ['org-members', session?.tenantId],
+    queryFn: async () => {
+      if (!session) return []
+      const response = await listOrgMembers(session)
+      return response.data
+    },
+    enabled: Boolean(session),
+  })
 
   const invitesQuery = useQuery({
     queryKey: ['org-invites', session?.tenantId],
     queryFn: async () => {
-      if (!session) return { items: [], nextCursor: null }
+      if (!session) return []
       const response = await listOrgInvites(session)
       return response.data
     },
@@ -77,9 +107,7 @@ export function TeamPage() {
   const createInviteMutation = useMutation({
     mutationFn: async () => {
       if (!session) throw new Error('Missing org session.')
-      if (!VALID_ROLES.includes(inviteForm.role)) {
-        throw new Error('Invalid role selected.')
-      }
+      if (!VALID_ROLES.includes(inviteForm.role)) throw new Error('Invalid role selected.')
       const response = await createOrgInvite(session, {
         email: inviteForm.email.trim(),
         role: inviteForm.role,
@@ -89,10 +117,12 @@ export function TeamPage() {
     onMutate: () => {
       setFormError(null)
       setSuccessMessage(null)
+      setLastCreatedInvite(null)
     },
     onSuccess: (invite) => {
       setInviteForm({ email: '', role: 'org_editor' })
-      setSuccessMessage(`Invite sent to ${invite.email} as ${ROLE_LABELS[invite.role]}.`)
+      setSuccessMessage(`Invite created for ${invite.email} as ${ROLE_LABELS[invite.role]}.`)
+      setLastCreatedInvite(invite)
       void queryClient.invalidateQueries({ queryKey: ['org-invites', session?.tenantId] })
     },
     onError: (error) => {
@@ -100,7 +130,27 @@ export function TeamPage() {
     },
   })
 
-  function handleSubmit(event: React.FormEvent) {
+  const removeMemberMutation = useMutation({
+    mutationFn: async (userId: string) => {
+      if (!session) throw new Error('Missing org session.')
+      await removeOrgMember(session, userId)
+      return userId
+    },
+    onSuccess: () => {
+      setPendingRemoveUserId(null)
+      void queryClient.invalidateQueries({ queryKey: ['org-members', session?.tenantId] })
+    },
+  })
+
+  const copyInviteLink = useCallback((invite: OrgInvite) => {
+    const link = buildInviteLink(invite.inviteId)
+    void navigator.clipboard.writeText(link).then(() => {
+      setCopiedInviteId(invite.inviteId)
+      setTimeout(() => setCopiedInviteId((prev) => (prev === invite.inviteId ? null : prev)), 2000)
+    })
+  }, [])
+
+  function handleInviteSubmit(event: React.FormEvent) {
     event.preventDefault()
     if (!inviteForm.email.trim()) {
       setFormError('Email is required.')
@@ -113,14 +163,119 @@ export function TeamPage() {
     createInviteMutation.mutate()
   }
 
+  const pendingInvites = (invitesQuery.data ?? []).filter((i) => i.status === 'pending')
+
   return (
     <div className="page-stack">
       <PageHero
         badge="Org portal"
-        title="Team"
-        description="Manage team membership and invite new members to access this tenant."
+        title="Users"
+        description="View and manage who has access to this tenant portal."
       />
 
+      {!canWrite ? (
+        <section className="content-panel content-panel--narrow">
+          <div className="designer-banner designer-banner--warning" role="status">
+            <strong>You have read-only access to this tenant.</strong>
+            <span>Contact an Org Admin to make changes.</span>
+          </div>
+        </section>
+      ) : null}
+
+      {/* Active members */}
+      <section className="content-panel">
+        <SectionHeader
+          eyebrow="Members"
+          title="Active users"
+          description="People with access to this tenant portal and their assigned roles."
+        />
+
+        {membersQuery.isLoading ? (
+          <LoadingState title="Loading members" message="Fetching team members for this tenant." />
+        ) : null}
+
+        {membersQuery.isError ? (
+          <ErrorState
+            title="Could not load members"
+            message="The members request failed. Check the org session or retry."
+            onRetry={() => void membersQuery.refetch()}
+          />
+        ) : null}
+
+        {!membersQuery.isLoading && !membersQuery.isError ? (
+          membersQuery.data?.length ? (
+            <div className="responsive-table">
+              <table className="data-table">
+                <thead>
+                  <tr>
+                    <th scope="col">User ID</th>
+                    <th scope="col">Role</th>
+                    <th scope="col">Status</th>
+                    <th scope="col">Joined</th>
+                    {isAdmin ? <th scope="col" aria-label="Actions" /> : null}
+                  </tr>
+                </thead>
+                <tbody>
+                  {membersQuery.data.map((member) => {
+                    const isPendingRemove = pendingRemoveUserId === member.userId
+                    return (
+                      <tr key={member.userId}>
+                        <td>{member.userId}</td>
+                        <td>{ROLE_LABELS[member.role]}</td>
+                        <td>
+                          <StatusChip tone={memberStatusTone(member.status)}>
+                            {member.status}
+                          </StatusChip>
+                        </td>
+                        <td>{formatDate(member.activatedAt)}</td>
+                        {isAdmin ? (
+                          <td className="data-table__actions">
+                            {isPendingRemove ? (
+                              <span className="data-table__confirm-row">
+                                <span>Remove this user?</span>
+                                <button
+                                  className="button button--danger button--small"
+                                  type="button"
+                                  disabled={removeMemberMutation.isPending}
+                                  onClick={() => removeMemberMutation.mutate(member.userId)}
+                                >
+                                  {removeMemberMutation.isPending ? 'Removing…' : 'Confirm'}
+                                </button>
+                                <button
+                                  className="button button--ghost button--small"
+                                  type="button"
+                                  onClick={() => setPendingRemoveUserId(null)}
+                                >
+                                  Cancel
+                                </button>
+                              </span>
+                            ) : (
+                              <button
+                                className="button button--ghost button--small"
+                                type="button"
+                                onClick={() => setPendingRemoveUserId(member.userId)}
+                              >
+                                Remove
+                              </button>
+                            )}
+                          </td>
+                        ) : null}
+                      </tr>
+                    )
+                  })}
+                </tbody>
+              </table>
+            </div>
+          ) : (
+            <EmptyState
+              title="No members yet"
+              message="Team members who accept their invites will appear here."
+            />
+          )
+        ) : null}
+      </section>
+
+      {/* Invite form */}
       {canWrite ? (
         <section className="content-panel content-panel--narrow">
           <SectionHeader
@@ -128,7 +283,7 @@ export function TeamPage() {
             title="Invite a team member"
             description="Sent invites are valid for 7 days. The recipient must register or sign in to accept."
           />
-          <form className="session-form" onSubmit={handleSubmit}>
+          <form className="session-form" onSubmit={handleInviteSubmit}>
             <label className="session-form__field">
               <span>Email address</span>
               <input
@@ -169,26 +324,32 @@ export function TeamPage() {
                 type="submit"
                 disabled={createInviteMutation.isPending}
               >
-                {createInviteMutation.isPending ? 'Sending...' : 'Send invite'}
+                {createInviteMutation.isPending ? 'Sending…' : 'Send invite'}
               </button>
             </div>
-            {formError ? (
-              <p className="session-form__error">{formError}</p>
-            ) : null}
-            {successMessage ? (
-              <p className="content-panel__body-copy">{successMessage}</p>
+            {formError ? <p className="session-form__error">{formError}</p> : null}
+            {successMessage && lastCreatedInvite ? (
+              <div className="session-form__success">
+                <p className="content-panel__body-copy">{successMessage}</p>
+                <div className="invite-link-row">
+                  <code className="invite-link-row__url">
+                    {buildInviteLink(lastCreatedInvite.inviteId)}
+                  </code>
+                  <button
+                    className="button button--ghost button--small"
+                    type="button"
+                    onClick={() => copyInviteLink(lastCreatedInvite)}
+                  >
+                    {copiedInviteId === lastCreatedInvite.inviteId ? 'Copied!' : 'Copy link'}
+                  </button>
+                </div>
+              </div>
             ) : null}
           </form>
         </section>
-      ) : (
-        <section className="content-panel content-panel--narrow">
-          <div className="designer-banner designer-banner--warning" role="status">
-            <strong>You have read-only access to this tenant.</strong>
-            <span>Contact an Org Admin to make changes.</span>
-          </div>
-        </section>
-      )}
+      ) : null}
 
+      {/* Pending invites */}
       <section className="content-panel">
         <SectionHeader
           eyebrow="Pending invites"
@@ -212,7 +373,7 @@ export function TeamPage() {
         ) : null}
 
         {!invitesQuery.isLoading && !invitesQuery.isError ? (
-          invitesQuery.data?.items.length ? (
+          pendingInvites.length ? (
             <div className="responsive-table">
               <table className="data-table">
                 <thead>
@@ -221,10 +382,11 @@ export function TeamPage() {
                     <th scope="col">Role</th>
                     <th scope="col">Status</th>
                     <th scope="col">Invited</th>
+                    <th scope="col" aria-label="Actions" />
                   </tr>
                 </thead>
                 <tbody>
-                  {invitesQuery.data.items.map((invite) => (
+                  {pendingInvites.map((invite) => (
                     <tr key={invite.inviteId}>
                       <td>{invite.email}</td>
                       <td>{ROLE_LABELS[invite.role]}</td>
@@ -233,7 +395,16 @@ export function TeamPage() {
                           {invite.status}
                         </StatusChip>
                       </td>
-                      <td>{formatInviteDate(invite.invitedAt)}</td>
+                      <td>{formatDate(invite.createdAt)}</td>
+                      <td className="data-table__actions">
+                        <button
+                          className="button button--ghost button--small"
+                          type="button"
+                          onClick={() => copyInviteLink(invite)}
+                        >
+                          {copiedInviteId === invite.inviteId ? 'Copied!' : 'Copy link'}
+                        </button>
+                      </td>
                     </tr>
                   ))}
                 </tbody>

--- a/src/pages/public/AboutUsPage.tsx
+++ b/src/pages/public/AboutUsPage.tsx
@@ -1,6 +1,45 @@
 import { Link } from 'react-router-dom'
 import { PageHero } from '../../components/layout/PageHero'
 
+const portalRoles = [
+  {
+    portal: 'Public',
+    role: 'Guest',
+    description: 'Browse the course catalog, view course details, and submit enrollment applications. No account required.',
+    badge: 'No login required',
+  },
+  {
+    portal: 'Org',
+    role: 'Org Viewer',
+    description: 'Read-only access to all data within a tenant — courses, submissions, branding, and audit history. Suited for auditors and external reviewers.',
+    badge: 'org_viewer',
+  },
+  {
+    portal: 'Org',
+    role: 'Org Editor',
+    description: 'Create and edit courses, design enrollment form schemas, and manage uploaded assets. Cannot change tenant settings or update submission statuses.',
+    badge: 'org_editor',
+  },
+  {
+    portal: 'Org',
+    role: 'Org Admin',
+    description: 'Full org-level control — everything an editor can do, plus updating submission statuses, managing tenant branding and settings, and inviting new team members.',
+    badge: 'org_admin',
+  },
+  {
+    portal: 'Internal',
+    role: 'Platform Support',
+    description: 'Cross-tenant support access. Can read org data within any specific tenant to assist with troubleshooting. Cannot write data or access internal management endpoints.',
+    badge: 'platform_support',
+  },
+  {
+    portal: 'Internal',
+    role: 'Internal Admin',
+    description: 'Platform operator access. Creates and manages tenants, provisions and manages users, assigns roles. Operates without a tenant context.',
+    badge: 'internal_admin',
+  },
+]
+
 const frontendStack = [
   { label: 'UI Framework', value: 'React 19 + TypeScript' },
   { label: 'Build Tool', value: 'Vite' },
@@ -78,16 +117,45 @@ export function AboutUsPage() {
         </div>
       </section>
 
+      {/* Roles & Access */}
+      <section className="content-panel">
+        <h2>Roles &amp; Access</h2>
+        <p>
+          OnlineForms uses a role-based access control system across three portal contexts.
+          Each role carries a precise set of permissions — no role inherits unnecessary
+          write access by default.
+        </p>
+        <div className="content-card-grid" style={{ marginTop: '1.25rem' }}>
+          {portalRoles.map((item) => (
+            <div key={item.badge} className="state-card" style={{ display: 'grid', gap: '0.5rem' }}>
+              <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: '0.5rem', flexWrap: 'wrap' }}>
+                <strong style={{ fontSize: '1rem', color: 'var(--color-text)' }}>{item.role}</strong>
+                <span className="page-hero__badge" style={{ fontFamily: 'monospace', fontSize: '0.75rem' }}>
+                  {item.badge}
+                </span>
+              </div>
+              <span style={{ fontSize: '0.78rem', fontWeight: 700, letterSpacing: '0.05em', textTransform: 'uppercase', color: 'var(--color-text-muted)' }}>
+                {item.portal} portal
+              </span>
+              <p style={{ margin: 0, color: 'var(--color-text-muted)', lineHeight: '1.65', fontSize: '0.93rem' }}>
+                {item.description}
+              </p>
+            </div>
+          ))}
+        </div>
+      </section>
+
       {/* Architecture */}
       <section className="content-panel">
         <h2>Architecture</h2>
         <p>
           OnlineForms is a full-stack serverless application. The frontend is a single-page
           app with three portal contexts — <strong>Public</strong> (learners),{' '}
-          <strong>Org</strong> (training providers), and <strong>Internal</strong> (platform
-          admins) — each with its own layout, navigation, and role-based access control. The
-          backend is a serverless REST API deployed on AWS, with DynamoDB as the primary
-          data store and Cognito handling authentication.
+          <strong>Org</strong> (training providers, with viewer / editor / admin roles),
+          and <strong>Internal</strong> (platform operators and support staff) — each with its
+          own layout, navigation, and role-based access control. The backend is a serverless
+          REST API deployed on AWS, with DynamoDB as the primary data store and Cognito
+          handling authentication.
         </p>
 
         <h3 style={{ marginTop: '1.5rem', marginBottom: '0.25rem', fontSize: '1rem', color: 'var(--color-text-muted)', fontWeight: 700, letterSpacing: '0.04em', textTransform: 'uppercase' }}>


### PR DESCRIPTION
## Summary

- **User Management (FU-01–FU-03):** new Users page in the org portal — active member list, invite form, remove member (org_admin), and copy invitation link
- **Role Redesign (FR-01–FR-05):** `org_viewer` read-only role, `platform_support` rename, centralised role labels, write-action guards across all org pages
- **Security Hardening (FS-01–FS-06):** enrollment form field constraints, 429 error state, honeypot, Cloudflare Turnstile CAPTCHA, XSS hygiene, dependency scanning

## User Management detail

- `GET /org/tenants/{tenantId}/members` — lists active members (userId, role, status, joined)
- `GET /org/tenants/{tenantId}/invites` — lists pending invites
- `DELETE /org/tenants/{tenantId}/members/{userId}` — remove member (`org_admin` only, inline confirm)
- `POST /org/tenants/{tenantId}/invites` — create invite (`org_editor`+); success state shows copy-link
- Copy link button on every pending invite row (`{origin}/org/accept-invite?inviteId={id}`)
- API type corrections: `OrgMember`/`OrgInvite` aligned to backend shapes (commit e97ce6a)
- Invite acceptance page (`/org/accept-invite`) is tracked as FU-04 (not in this PR)

## Test plan

- [x] `tsc --noEmit` passes (zero errors)
- [x] All 50 frontend tests pass
- [ ] Smoke: log in as `org_admin` → Users page shows member list, Remove works with confirm
- [ ] Smoke: log in as `org_editor` → Users page shows members, invite form visible, no Remove button
- [ ] Smoke: log in as `org_viewer` → Users page read-only, no invite form, no Remove button
- [ ] Smoke: create invite → success state shows invite link, Copy link writes to clipboard
- [ ] Smoke: Copy link button on pending invite row shows "Copied!" feedback

## Spec docs

- `docs/specs/PHASE_USER_MANAGEMENT_FRONTEND.md` — FU-01–FU-04
- `docs/specs/PHASE_ROLE_REDESIGN_FRONTEND.md` — FR-01–FR-05
- `docs/specs/PHASE_SECURITY_FRONTEND.md` — FS-01–FS-06
- `docs/specs/FRONTEND_IMPLEMENTATION_CHECKLIST.md` — updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)