### PR TITLE
fix(org): add session?.tenantId to copyInviteLink useCallback deps

### DIFF
--- a/src/pages/org/TeamPage.tsx
+++ b/src/pages/org/TeamPage.tsx
@@ -148,7 +148,7 @@ export function TeamPage() {
       setCopiedInviteId(invite.inviteId)
       setTimeout(() => setCopiedInviteId((prev) => (prev === invite.inviteId ? null : prev)), 2000)
     })
-  }, [])
+  }, [session?.tenantId])
 
   function handleInviteSubmit(event: React.FormEvent) {
     event.preventDefault()


### PR DESCRIPTION
## Summary

Fixes a React Compiler lint error introduced in #91.

`copyInviteLink` in `TeamPage.tsx` was memoised with an empty dependency array `[]` but reads `session?.tenantId` after the `buildInviteLink` signature was updated to include `tenantId`. Adding the missing dependency satisfies both `react-hooks/exhaustive-deps` and the React Compiler's memoisation preservation check.

## Root cause

`buildInviteLink` previously took only `inviteId`; the FU-04 commit added `tenantId` as a second argument and passed `session?.tenantId` inline, but the `useCallback` deps array was not updated at the same time.

## Test plan

- [x] `npm run lint` — zero errors/warnings
- [x] `tsc --noEmit` — zero errors
- [x] 54/54 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)