### PR TITLE
fix(nav): add Users link to org portal sidebar

### DIFF
--- a/src/components/layout/OrgSidebar.tsx
+++ b/src/components/layout/OrgSidebar.tsx
@@ -8,6 +8,7 @@ type OrgSidebarProps = {
 const navItems = [
   { to: '/org/courses', label: 'Courses' },
   { to: '/org/submissions', label: 'Submissions' },
+  { to: '/org/team', label: 'Users' },
   { to: '/org/branding', label: 'Branding' },
   { to: '/org/audit', label: 'Audit' },
   { to: '/org/settings', label: 'Settings' },


### PR DESCRIPTION
## Summary

The **Users** page (`/org/team`) was built and routed correctly but never added to `OrgSidebar`'s `navItems`, making it unreachable from the portal navigation.

Adds a **Users** nav item between Submissions and Branding.

## Test plan

- [x] `npm run lint` — clean
- [x] `tsc --noEmit` — clean
- [x] 54/54 tests pass
- [ ] Smoke: org portal sidebar shows Users link; clicking navigates to the member list

🤖 Generated with [Claude Code](https://claude.com/claude-code)