### PR TITLE
feat: form scheme templates UI

### DIFF
--- a/src/app/routes.tsx
+++ b/src/app/routes.tsx
@@ -11,6 +11,8 @@ import { BrandingPage } from '../pages/org/BrandingPage'
 import { CourseEditorPage } from '../pages/org/CourseEditorPage'
 import { CoursesPage } from '../pages/org/CoursesPage'
 import { FormDesignerPage } from '../pages/org/FormDesignerPage'
+import { FormTemplatesPage } from '../pages/org/FormTemplatesPage'
+import { FormTemplateEditorPage } from '../pages/org/FormTemplateEditorPage'
 import { OrgSettingsPage } from '../pages/org/OrgSettingsPage'
 import { AcceptInvitePage } from '../pages/org/AcceptInvitePage'
 import { TeamPage } from '../pages/org/TeamPage'
@@ -164,6 +166,14 @@ export const appRoutes: RouteObject[] = [
               {
                 path: 'team',
                 element: <TeamPage />,
+              },
+              {
+                path: 'form-templates',
+                element: <FormTemplatesPage />,
+              },
+              {
+                path: 'form-templates/:templateId',
+                element: <FormTemplateEditorPage />,
               },
             ],
           },

--- a/src/components/layout/OrgSidebar.tsx
+++ b/src/components/layout/OrgSidebar.tsx
@@ -7,6 +7,7 @@ type OrgSidebarProps = {
 
 const navItems = [
   { to: '/org/courses', label: 'Courses' },
+  { to: '/org/form-templates', label: 'Form Templates' },
   { to: '/org/submissions', label: 'Submissions' },
   { to: '/org/team', label: 'Users' },
   { to: '/org/branding', label: 'Branding' },

--- a/src/lib/api/org.ts
+++ b/src/lib/api/org.ts
@@ -37,6 +37,9 @@ import type {
   UserSessionContext,
   UploadTicketRequest,
   UploadTicketResponse,
+  FormTemplate,
+  FormTemplateCreatePayload,
+  FormTemplateUpdatePayload,
 } from './types'
 
 type BackendPage = {
@@ -902,6 +905,65 @@ export function createOrgInvite(
 export function revokeOrgInvite(session: OrgSessionHeaders, inviteId: string) {
   return apiRequest<BackendItemEnvelope<{ revoked: boolean; inviteId: string }>>({
     path: `/org/tenants/${session.tenantId}/invites/${inviteId}`,
+    method: 'DELETE',
+    session,
+  }).then((response) => ({
+    ...response,
+    data: response.data.data,
+  }))
+}
+
+export function listFormTemplates(session: OrgSessionHeaders) {
+  return apiRequest<BackendItemEnvelope<FormTemplate[]>>({
+    path: '/org/form-templates',
+    session,
+  }).then((response) => ({
+    ...response,
+    data: response.data.data,
+  }))
+}
+
+export function getFormTemplate(session: OrgSessionHeaders, templateId: string) {
+  return apiRequest<BackendItemEnvelope<FormTemplate>>({
+    path: `/org/form-templates/${templateId}`,
+    session,
+  }).then((response) => ({
+    ...response,
+    data: response.data.data,
+  }))
+}
+
+export function createFormTemplate(session: OrgSessionHeaders, payload: FormTemplateCreatePayload) {
+  return apiRequest<BackendItemEnvelope<FormTemplate>>({
+    path: '/org/form-templates',
+    method: 'POST',
+    session,
+    body: payload,
+  }).then((response) => ({
+    ...response,
+    data: response.data.data,
+  }))
+}
+
+export function updateFormTemplate(
+  session: OrgSessionHeaders,
+  templateId: string,
+  payload: FormTemplateUpdatePayload,
+) {
+  return apiRequest<BackendItemEnvelope<FormTemplate>>({
+    path: `/org/form-templates/${templateId}`,
+    method: 'PATCH',
+    session,
+    body: payload,
+  }).then((response) => ({
+    ...response,
+    data: response.data.data,
+  }))
+}
+
+export function deleteFormTemplate(session: OrgSessionHeaders, templateId: string) {
+  return apiRequest<BackendItemEnvelope<{ deleted: boolean; templateId: string }>>({
+    path: `/org/form-templates/${templateId}`,
     method: 'DELETE',
     session,
   }).then((response) => ({

--- a/src/lib/api/types.ts
+++ b/src/lib/api/types.ts
@@ -187,6 +187,30 @@ export type FormSchemaUpsertPayload = {
   fields: FormField[]
 }
 
+export type FormTemplate = {
+  templateId: string
+  tenantId: string
+  name: string
+  description: string | null
+  fields: FormField[]
+  createdAt: string
+  updatedAt: string
+  createdBy: string
+  updatedBy: string
+}
+
+export type FormTemplateCreatePayload = {
+  name: string
+  description?: string | null
+  fields: FormField[]
+}
+
+export type FormTemplateUpdatePayload = {
+  name?: string
+  description?: string | null
+  fields?: FormField[]
+}
+
 export type FormSchemaUpsertResponse = {
   formId: string
   version: number

--- a/src/pages/org/FormDesignerPage.tsx
+++ b/src/pages/org/FormDesignerPage.tsx
@@ -10,10 +10,12 @@ import { useOrgSession } from '../../features/org-session/useOrgSession'
 import {
   ApiClientError,
   getLatestFormSchema,
+  listFormTemplates,
   type FormField,
   type FormFieldType,
   type FormSchema,
   type FormSchemaUpsertResponse,
+  type FormTemplate,
   type OrgSessionHeaders,
   upsertFormSchema,
 } from '../../lib/api'
@@ -125,6 +127,7 @@ type FormDesignerEditorProps = {
   initialFields: FormField[]
   queryKey: string[]
   session: OrgSessionHeaders
+  availableTemplates?: FormTemplate[]
 }
 
 function FormDesignerEditor({
@@ -136,6 +139,7 @@ function FormDesignerEditor({
   initialFields,
   queryKey,
   session,
+  availableTemplates = [],
 }: FormDesignerEditorProps) {
   const queryClient = useQueryClient()
   const [editableFields, setEditableFields] =
@@ -144,6 +148,8 @@ function FormDesignerEditor({
     initialFields[0]?.fieldId ?? null,
   )
   const [saveMessage, setSaveMessage] = useState<string | null>(null)
+  const [templateApplied, setTemplateApplied] = useState(false)
+  const [selectedTemplateId, setSelectedTemplateId] = useState('')
 
   const initialPayload = useMemo(
     () => buildFormSchemaUpsertPayload(initialFields),
@@ -278,7 +284,50 @@ function FormDesignerEditor({
           <p className="section-heading__eyebrow">Schema summary</p>
           <h2>Version {version ?? 'Draft'}</h2>
         </div>
-        {isNewSchema ? (
+        {isNewSchema && !templateApplied && availableTemplates.length > 0 ? (
+          <div className="designer-banner designer-banner--warning" role="status">
+            <strong>Start from a template?</strong>
+            <span>Pre-populate the field list from a saved template, or skip to begin with the default fields.</span>
+            <div className="button-row" style={{ marginTop: '0.5rem' }}>
+              <select
+                value={selectedTemplateId}
+                onChange={(event) => setSelectedTemplateId(event.target.value)}
+                style={{ flexShrink: 0 }}
+              >
+                <option value="">— choose a template —</option>
+                {availableTemplates.map((tpl) => (
+                  <option key={tpl.templateId} value={tpl.templateId}>
+                    {tpl.name} ({tpl.fields.length} field{tpl.fields.length !== 1 ? 's' : ''})
+                  </option>
+                ))}
+              </select>
+              <button
+                className="button button--primary"
+                disabled={!selectedTemplateId}
+                onClick={() => {
+                  const tpl = availableTemplates.find((t) => t.templateId === selectedTemplateId)
+                  if (tpl) {
+                    const reindexed = withDisplayOrder(tpl.fields)
+                    setEditableFields(reindexed)
+                    setSelectedFieldId(reindexed[0]?.fieldId ?? null)
+                  }
+                  setTemplateApplied(true)
+                }}
+                type="button"
+              >
+                Apply template
+              </button>
+              <button
+                className="button button--ghost"
+                onClick={() => setTemplateApplied(true)}
+                type="button"
+              >
+                Skip
+              </button>
+            </div>
+          </div>
+        ) : null}
+        {isNewSchema && (templateApplied || availableTemplates.length === 0) ? (
           <div className="designer-banner designer-banner--warning" role="status">
             <strong>No form template exists yet.</strong>
             <span>Add fields and save to create the first enrollment form version for this course.</span>
@@ -657,6 +706,17 @@ export function FormDesignerPage() {
   const { session } = useOrgSession()
   const canWrite = useCanWrite()
   const { courseId = '' } = useParams()
+
+  const templatesQuery = useQuery({
+    queryKey: ['org-form-templates', session?.tenantId],
+    queryFn: async () => {
+      if (!session) return []
+      const response = await listFormTemplates(session)
+      return response.data
+    },
+    enabled: Boolean(session),
+  })
+
   const schemaQuery = useQuery({
     queryKey: ['org-form-schema', session?.tenantId, courseId],
     queryFn: async () => {
@@ -717,6 +777,7 @@ export function FormDesignerPage() {
           queryKey={['org-form-schema', session?.tenantId || '', courseId]}
           session={session}
           version={schemaQuery.data?.schema.version}
+          availableTemplates={templatesQuery.data ?? []}
         />
       ) : null}
 

--- a/src/pages/org/FormTemplateEditorPage.tsx
+++ b/src/pages/org/FormTemplateEditorPage.tsx
@@ -1,0 +1,610 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { useMemo, useState } from 'react'
+import { Link, useNavigate, useParams } from 'react-router-dom'
+import { ErrorState } from '../../components/feedback/ErrorState'
+import { LoadingState } from '../../components/feedback/LoadingState'
+import { PageHero } from '../../components/layout/PageHero'
+import { buildFormSchemaUpsertPayload } from '../../features/form-designer/schemaPayload'
+import { useCanWrite } from '../../features/org-session/useCanWrite'
+import { useOrgSession } from '../../features/org-session/useOrgSession'
+import {
+  createFormTemplate,
+  getFormTemplate,
+  updateFormTemplate,
+  type FormField,
+  type FormFieldType,
+  type FormTemplate,
+} from '../../lib/api'
+
+const fieldTypeOptions: Array<{ value: FormFieldType; label: string }> = [
+  { value: 'short_text', label: 'Short text' },
+  { value: 'long_text', label: 'Long text' },
+  { value: 'email', label: 'Email' },
+  { value: 'phone', label: 'Phone' },
+  { value: 'number', label: 'Number' },
+  { value: 'single_select', label: 'Single select' },
+  { value: 'multi_select', label: 'Multi select' },
+  { value: 'checkbox', label: 'Checkbox' },
+  { value: 'date', label: 'Date' },
+]
+
+function createDraftField(position: number): FormField {
+  return {
+    fieldId: `field_${position + 1}`,
+    type: 'short_text',
+    label: `New field ${position + 1}`,
+    helpText: '',
+    required: false,
+    displayOrder: position + 1,
+    options: [],
+    validation: {},
+  }
+}
+
+function withDisplayOrder(fields: FormField[]) {
+  return fields.map((field, index) => ({
+    ...field,
+    displayOrder: index + 1,
+  }))
+}
+
+type TemplateEditorProps = {
+  canWrite: boolean
+  initialName: string
+  initialDescription: string
+  initialFields: FormField[]
+  isCreateMode: boolean
+  templateId: string
+  session: NonNullable<ReturnType<typeof useOrgSession>['session']>
+}
+
+function TemplateEditor({
+  canWrite,
+  initialName,
+  initialDescription,
+  initialFields,
+  isCreateMode,
+  templateId,
+  session,
+}: TemplateEditorProps) {
+  const navigate = useNavigate()
+  const queryClient = useQueryClient()
+  const [name, setName] = useState(initialName)
+  const [description, setDescription] = useState(initialDescription)
+  const [editableFields, setEditableFields] = useState<FormField[]>(initialFields)
+  const [selectedFieldId, setSelectedFieldId] = useState<string | null>(
+    initialFields[0]?.fieldId ?? null,
+  )
+  const [saveMessage, setSaveMessage] = useState<string | null>(null)
+
+  const initialPayload = useMemo(
+    () => buildFormSchemaUpsertPayload(initialFields),
+    [initialFields],
+  )
+  const draftPayload = useMemo(
+    () => buildFormSchemaUpsertPayload(editableFields),
+    [editableFields],
+  )
+
+  const hasUnsavedChanges =
+    name !== initialName ||
+    description !== initialDescription ||
+    JSON.stringify(initialPayload) !== JSON.stringify(draftPayload)
+
+  const selectedField =
+    editableFields.find((field) => field.fieldId === selectedFieldId) ?? null
+
+  const saveMutation = useMutation<FormTemplate, Error, void>({
+    mutationFn: async () => {
+      if (isCreateMode) {
+        const response = await createFormTemplate(session, {
+          name: name.trim(),
+          description: description.trim() || null,
+          fields: draftPayload.fields,
+        })
+        return response.data
+      } else {
+        const response = await updateFormTemplate(session, templateId, {
+          name: name.trim(),
+          description: description.trim() || null,
+          fields: draftPayload.fields,
+        })
+        return response.data
+      }
+    },
+    onMutate: () => {
+      setSaveMessage(null)
+    },
+    onSuccess: (result) => {
+      queryClient.setQueryData(['org-form-template', session.tenantId, result.templateId], result)
+      queryClient.invalidateQueries({ queryKey: ['org-form-templates', session.tenantId] })
+      setSaveMessage('Template saved successfully.')
+      if (isCreateMode) {
+        navigate(`/org/form-templates/${result.templateId}`, { replace: true })
+      }
+    },
+  })
+
+  function updateSelectedField(updater: (field: FormField) => FormField) {
+    setEditableFields((currentFields) =>
+      currentFields.map((field) =>
+        field.fieldId === selectedFieldId ? updater(field) : field,
+      ),
+    )
+  }
+
+  function addField() {
+    const nextField = createDraftField(editableFields.length)
+    setEditableFields((currentFields) => withDisplayOrder([...currentFields, nextField]))
+    setSelectedFieldId(nextField.fieldId)
+  }
+
+  function moveSelectedField(direction: 'up' | 'down') {
+    if (!selectedFieldId) return
+    setEditableFields((currentFields) => {
+      const index = currentFields.findIndex((field) => field.fieldId === selectedFieldId)
+      if (index < 0) return currentFields
+      const targetIndex = direction === 'up' ? index - 1 : index + 1
+      if (targetIndex < 0 || targetIndex >= currentFields.length) return currentFields
+      const nextFields = [...currentFields]
+      const [selected] = nextFields.splice(index, 1)
+      nextFields.splice(targetIndex, 0, selected)
+      return withDisplayOrder(nextFields)
+    })
+  }
+
+  function addOption() {
+    updateSelectedField((field) => ({
+      ...field,
+      options: [
+        ...(field.options ?? []),
+        {
+          value: `option_${(field.options?.length ?? 0) + 1}`,
+          label: `Option ${(field.options?.length ?? 0) + 1}`,
+        },
+      ],
+    }))
+  }
+
+  function updateOption(optionIndex: number, key: 'label' | 'value', value: string) {
+    updateSelectedField((field) => ({
+      ...field,
+      options: (field.options ?? []).map((option, index) =>
+        index === optionIndex ? { ...option, [key]: value } : option,
+      ),
+    }))
+  }
+
+  function removeOption(optionIndex: number) {
+    updateSelectedField((field) => ({
+      ...field,
+      options: (field.options ?? []).filter((_, index) => index !== optionIndex),
+    }))
+  }
+
+  function handleFieldIdChange(nextFieldId: string) {
+    updateSelectedField((field) => ({ ...field, fieldId: nextFieldId }))
+    setSelectedFieldId(nextFieldId)
+  }
+
+  return (
+    <>
+      <section className="content-panel">
+        <div className="section-heading">
+          <p className="section-heading__eyebrow">Template details</p>
+          <h2>{isCreateMode ? 'New template' : name || 'Edit template'}</h2>
+        </div>
+        <div className="designer-editor-grid">
+          <label className="session-form__field">
+            <span>Template name <span aria-hidden="true">*</span></span>
+            <input
+              disabled={!canWrite}
+              maxLength={120}
+              onChange={(event) => setName(event.target.value)}
+              placeholder="e.g. Standard enrollment form"
+              type="text"
+              value={name}
+            />
+          </label>
+          <label className="session-form__field">
+            <span>Description</span>
+            <textarea
+              className="designer-textarea"
+              disabled={!canWrite}
+              onChange={(event) => setDescription(event.target.value)}
+              placeholder="Describe when to use this template."
+              rows={2}
+              value={description}
+            />
+          </label>
+        </div>
+      </section>
+
+      <section className="designer-grid">
+        <section className="content-panel">
+          <div className="section-heading">
+            <p className="section-heading__eyebrow">Field list</p>
+            <h2>Template fields</h2>
+          </div>
+          {!canWrite ? (
+            <div className="designer-banner designer-banner--warning" role="status">
+              <strong>You have read-only access to this tenant.</strong>
+              <span>Contact an Org Admin to make changes.</span>
+            </div>
+          ) : null}
+          {canWrite ? (
+            <div className="button-row">
+              <button className="button button--primary" onClick={addField} type="button">
+                Add field
+              </button>
+              <button
+                className="button button--ghost"
+                disabled={!selectedField}
+                onClick={() => moveSelectedField('up')}
+                type="button"
+              >
+                Move up
+              </button>
+              <button
+                className="button button--ghost"
+                disabled={!selectedField}
+                onClick={() => moveSelectedField('down')}
+                type="button"
+              >
+                Move down
+              </button>
+              <button
+                className="button button--secondary"
+                disabled={
+                  !name.trim() ||
+                  !editableFields.length ||
+                  !hasUnsavedChanges ||
+                  saveMutation.isPending
+                }
+                onClick={() => saveMutation.mutate()}
+                type="button"
+              >
+                {saveMutation.isPending ? 'Saving...' : 'Save template'}
+              </button>
+            </div>
+          ) : null}
+          {canWrite && hasUnsavedChanges ? (
+            <div className="designer-banner designer-banner--warning" role="status">
+              <strong>Unsaved changes.</strong>
+              <span>Save to update the template.</span>
+            </div>
+          ) : null}
+          {saveMutation.isError ? (
+            <div className="designer-banner designer-banner--error" role="alert">
+              <strong>{saveMutation.error.message}</strong>
+              <span>Review the template and try again.</span>
+            </div>
+          ) : null}
+          {saveMessage && !hasUnsavedChanges ? (
+            <div className="designer-banner designer-banner--success" role="status">
+              <strong>{saveMessage}</strong>
+            </div>
+          ) : null}
+          {editableFields.length ? (
+            <div className="designer-field-list">
+              {editableFields.map((field) => (
+                <button
+                  key={field.fieldId}
+                  className={
+                    field.fieldId === selectedFieldId
+                      ? 'designer-field-card designer-field-card--selected'
+                      : 'designer-field-card'
+                  }
+                  onClick={() => setSelectedFieldId(field.fieldId)}
+                  type="button"
+                >
+                  <div>
+                    <p className="designer-field-card__eyebrow">
+                      {field.type.replace(/_/g, ' ')}
+                    </p>
+                    <h3>{field.label}</h3>
+                    <p>{field.helpText || 'No helper text set yet.'}</p>
+                  </div>
+                  <div className="designer-field-card__meta">
+                    <span>ID: {field.fieldId}</span>
+                    <span>Required: {field.required ? 'Yes' : 'No'}</span>
+                    <span>Order: {field.displayOrder ?? 'Not specified'}</span>
+                  </div>
+                </button>
+              ))}
+            </div>
+          ) : (
+            <div className="designer-empty-panel">
+              <h3>No fields yet</h3>
+              <p>Add fields to define the template structure.</p>
+            </div>
+          )}
+        </section>
+
+        {canWrite ? (
+          <section className="content-panel">
+            <div className="section-heading">
+              <p className="section-heading__eyebrow">Field editor</p>
+              <h2>Core field properties</h2>
+            </div>
+            {selectedField ? (
+              <div className="designer-editor-grid">
+                <label className="session-form__field">
+                  <span>Field ID</span>
+                  <input
+                    onChange={(event) => handleFieldIdChange(event.target.value)}
+                    type="text"
+                    value={selectedField.fieldId}
+                  />
+                </label>
+                <label className="session-form__field">
+                  <span>Label</span>
+                  <input
+                    onChange={(event) =>
+                      updateSelectedField((field) => ({ ...field, label: event.target.value }))
+                    }
+                    type="text"
+                    value={selectedField.label}
+                  />
+                </label>
+                <label className="session-form__field">
+                  <span>Help text</span>
+                  <textarea
+                    className="designer-textarea"
+                    onChange={(event) =>
+                      updateSelectedField((field) => ({ ...field, helpText: event.target.value }))
+                    }
+                    rows={3}
+                    value={selectedField.helpText || ''}
+                  />
+                </label>
+                <label className="session-form__field">
+                  <span>Field type</span>
+                  <select
+                    onChange={(event) =>
+                      updateSelectedField((field) => ({
+                        ...field,
+                        type: event.target.value as FormFieldType,
+                      }))
+                    }
+                    value={selectedField.type}
+                  >
+                    {fieldTypeOptions.map((option) => (
+                      <option key={option.value} value={option.value}>
+                        {option.label}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+                <label className="designer-checkbox-row">
+                  <input
+                    checked={Boolean(selectedField.required)}
+                    onChange={(event) =>
+                      updateSelectedField((field) => ({ ...field, required: event.target.checked }))
+                    }
+                    type="checkbox"
+                  />
+                  <span>Required field</span>
+                </label>
+                <section className="designer-subpanel">
+                  <div className="section-heading">
+                    <p className="section-heading__eyebrow">Validation</p>
+                    <h2>Field rules</h2>
+                  </div>
+                  <div className="designer-editor-grid">
+                    <label className="session-form__field">
+                      <span>Min length</span>
+                      <input
+                        onChange={(event) =>
+                          updateSelectedField((field) => ({
+                            ...field,
+                            validation: {
+                              ...field.validation,
+                              minLength: event.target.value ? Number(event.target.value) : undefined,
+                            },
+                          }))
+                        }
+                        type="number"
+                        value={selectedField.validation?.minLength ?? ''}
+                      />
+                    </label>
+                    <label className="session-form__field">
+                      <span>Max length</span>
+                      <input
+                        onChange={(event) =>
+                          updateSelectedField((field) => ({
+                            ...field,
+                            validation: {
+                              ...field.validation,
+                              maxLength: event.target.value ? Number(event.target.value) : undefined,
+                            },
+                          }))
+                        }
+                        type="number"
+                        value={selectedField.validation?.maxLength ?? ''}
+                      />
+                    </label>
+                    <label className="session-form__field">
+                      <span>Min value</span>
+                      <input
+                        onChange={(event) =>
+                          updateSelectedField((field) => ({
+                            ...field,
+                            validation: {
+                              ...field.validation,
+                              min: event.target.value ? Number(event.target.value) : undefined,
+                            },
+                          }))
+                        }
+                        type="number"
+                        value={selectedField.validation?.min ?? ''}
+                      />
+                    </label>
+                    <label className="session-form__field">
+                      <span>Max value</span>
+                      <input
+                        onChange={(event) =>
+                          updateSelectedField((field) => ({
+                            ...field,
+                            validation: {
+                              ...field.validation,
+                              max: event.target.value ? Number(event.target.value) : undefined,
+                            },
+                          }))
+                        }
+                        type="number"
+                        value={selectedField.validation?.max ?? ''}
+                      />
+                    </label>
+                    <label className="session-form__field">
+                      <span>Pattern</span>
+                      <input
+                        onChange={(event) =>
+                          updateSelectedField((field) => ({
+                            ...field,
+                            validation: {
+                              ...field.validation,
+                              pattern: event.target.value || undefined,
+                            },
+                          }))
+                        }
+                        placeholder="^[A-Za-z]+$"
+                        type="text"
+                        value={selectedField.validation?.pattern ?? ''}
+                      />
+                    </label>
+                  </div>
+                </section>
+
+                {selectedField.type === 'single_select' || selectedField.type === 'multi_select' ? (
+                  <section className="designer-subpanel">
+                    <div className="section-heading">
+                      <p className="section-heading__eyebrow">Options</p>
+                      <h2>Select field choices</h2>
+                    </div>
+                    <div className="button-row">
+                      <button
+                        className="button button--secondary"
+                        onClick={addOption}
+                        type="button"
+                      >
+                        Add option
+                      </button>
+                    </div>
+                    {(selectedField.options ?? []).length ? (
+                      <div className="designer-option-list">
+                        {(selectedField.options ?? []).map((option, optionIndex) => (
+                          <div
+                            key={`${option.value}-${optionIndex}`}
+                            className="designer-option-row"
+                          >
+                            <input
+                              onChange={(event) =>
+                                updateOption(optionIndex, 'label', event.target.value)
+                              }
+                              placeholder="Label"
+                              type="text"
+                              value={option.label}
+                            />
+                            <input
+                              onChange={(event) =>
+                                updateOption(optionIndex, 'value', event.target.value)
+                              }
+                              placeholder="Value"
+                              type="text"
+                              value={option.value}
+                            />
+                            <button
+                              className="button button--ghost"
+                              onClick={() => removeOption(optionIndex)}
+                              type="button"
+                            >
+                              Remove
+                            </button>
+                          </div>
+                        ))}
+                      </div>
+                    ) : (
+                      <div className="designer-empty-panel">
+                        <h3>No options configured</h3>
+                        <p>Add the selectable values for this field.</p>
+                      </div>
+                    )}
+                  </section>
+                ) : null}
+              </div>
+            ) : (
+              <div className="designer-empty-panel">
+                <h3>No field selected</h3>
+                <p>Choose an existing field or add a new one to start editing its properties.</p>
+              </div>
+            )}
+          </section>
+        ) : null}
+      </section>
+    </>
+  )
+}
+
+export function FormTemplateEditorPage() {
+  const { session } = useOrgSession()
+  const canWrite = useCanWrite()
+  const { templateId = '' } = useParams()
+  const isCreateMode = templateId === 'new'
+
+  const templateQuery = useQuery({
+    queryKey: ['org-form-template', session?.tenantId, templateId],
+    queryFn: async () => {
+      if (!session) throw new Error('Missing session.')
+      const response = await getFormTemplate(session, templateId)
+      return response.data
+    },
+    enabled: Boolean(session && !isCreateMode),
+  })
+
+  return (
+    <div className="page-stack">
+      <PageHero
+        badge="Form templates"
+        title={isCreateMode ? 'Create form template' : 'Edit form template'}
+        description="Define a reusable set of enrollment fields that can be applied when setting up a new course form."
+      />
+
+      {!isCreateMode && templateQuery.isLoading ? (
+        <LoadingState title="Loading template" message="Fetching template details." />
+      ) : null}
+
+      {!isCreateMode && templateQuery.isError ? (
+        <ErrorState
+          title="Could not load template"
+          message="The template could not be loaded. Check the org session or retry."
+        />
+      ) : null}
+
+      {session && (isCreateMode || (!templateQuery.isLoading && !templateQuery.isError)) ? (
+        <TemplateEditor
+          key={templateId}
+          canWrite={canWrite}
+          initialName={templateQuery.data?.name ?? ''}
+          initialDescription={templateQuery.data?.description ?? ''}
+          initialFields={templateQuery.data?.fields ?? []}
+          isCreateMode={isCreateMode}
+          templateId={templateId}
+          session={session}
+        />
+      ) : null}
+
+      <section className="content-panel content-panel--narrow">
+        <div className="section-heading">
+          <p className="section-heading__eyebrow">Template library</p>
+          <h2>Return to all templates</h2>
+        </div>
+        <div className="button-row">
+          <Link className="button button--secondary" to="/org/form-templates">
+            Back to templates
+          </Link>
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/src/pages/org/FormTemplatesPage.tsx
+++ b/src/pages/org/FormTemplatesPage.tsx
@@ -1,0 +1,177 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { useState } from 'react'
+import { Link, useNavigate } from 'react-router-dom'
+import { EmptyState } from '../../components/feedback/EmptyState'
+import { ErrorState } from '../../components/feedback/ErrorState'
+import { LoadingState } from '../../components/feedback/LoadingState'
+import { PageHero } from '../../components/layout/PageHero'
+import { useCanWrite } from '../../features/org-session/useCanWrite'
+import { useOrgSession } from '../../features/org-session/useOrgSession'
+import { deleteFormTemplate, listFormTemplates } from '../../lib/api'
+
+function formatLocalDate(value?: string | null) {
+  if (!value) return '—'
+  const date = new Date(value)
+  return Number.isNaN(date.getTime()) ? value : date.toLocaleDateString()
+}
+
+export function FormTemplatesPage() {
+  const { session } = useOrgSession()
+  const canWrite = useCanWrite()
+  const navigate = useNavigate()
+  const queryClient = useQueryClient()
+  const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null)
+
+  const templatesQuery = useQuery({
+    queryKey: ['org-form-templates', session?.tenantId],
+    queryFn: async () => {
+      if (!session) return []
+      const response = await listFormTemplates(session)
+      return response.data
+    },
+    enabled: Boolean(session),
+  })
+
+  const deleteMutation = useMutation({
+    mutationFn: async (templateId: string) => {
+      if (!session) throw new Error('Missing session.')
+      await deleteFormTemplate(session, templateId)
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['org-form-templates', session?.tenantId] })
+      setConfirmDeleteId(null)
+    },
+  })
+
+  return (
+    <div className="page-stack">
+      <PageHero
+        badge="Org workspace"
+        variant="org"
+        title="Form Schema Templates"
+        description="Build and maintain reusable field sets that can be applied as a starting point when designing a new course enrollment form."
+      />
+
+      {templatesQuery.isLoading ? (
+        <LoadingState
+          title="Loading templates"
+          message="Fetching form schema templates for this tenant."
+        />
+      ) : null}
+
+      {templatesQuery.isError ? (
+        <ErrorState
+          title="Could not load templates"
+          message="The template list request failed. Check the org session or retry."
+        />
+      ) : null}
+
+      {!templatesQuery.isLoading && !templatesQuery.isError ? (
+        templatesQuery.data?.length ? (
+          <section className="content-panel">
+            <div className="section-header">
+              <div className="section-header__copy">
+                <p className="section-heading__eyebrow">Template library</p>
+                <h2>
+                  {templatesQuery.data.length} template
+                  {templatesQuery.data.length !== 1 ? 's' : ''}
+                </h2>
+              </div>
+              {canWrite ? (
+                <div className="section-header__actions">
+                  <Link className="button button--primary" to="/org/form-templates/new">
+                    Create template
+                  </Link>
+                </div>
+              ) : null}
+            </div>
+
+            <div className="org-course-card-grid">
+              {templatesQuery.data.map((template) => (
+                <div key={template.templateId} className="org-course-card">
+                  <div className="org-course-card__header">
+                    <div className="org-course-card__title-row">
+                      <strong className="org-course-card__title">{template.name}</strong>
+                    </div>
+                    {template.description ? (
+                      <p className="org-course-card__summary">{template.description}</p>
+                    ) : null}
+                  </div>
+
+                  <div className="org-course-card__meta">
+                    <span className="org-course-card__meta-item">
+                      <span className="org-course-card__meta-label">Fields</span>
+                      {template.fields.length}
+                    </span>
+                    <span className="org-course-card__meta-item">
+                      <span className="org-course-card__meta-label">Last updated</span>
+                      {formatLocalDate(template.updatedAt)}
+                    </span>
+                  </div>
+
+                  <div className="org-course-card__actions">
+                    {canWrite ? (
+                      <Link
+                        className="button button--outline"
+                        to={`/org/form-templates/${template.templateId}`}
+                      >
+                        Edit
+                      </Link>
+                    ) : null}
+
+                    {canWrite && confirmDeleteId === template.templateId ? (
+                      <div className="button-row">
+                        <span style={{ fontSize: '0.875rem', alignSelf: 'center' }}>Delete?</span>
+                        <button
+                          className="button button--ghost"
+                          disabled={deleteMutation.isPending}
+                          onClick={() => deleteMutation.mutate(template.templateId)}
+                          type="button"
+                        >
+                          {deleteMutation.isPending ? 'Deleting...' : 'Confirm'}
+                        </button>
+                        <button
+                          className="button button--ghost"
+                          onClick={() => setConfirmDeleteId(null)}
+                          type="button"
+                        >
+                          Cancel
+                        </button>
+                      </div>
+                    ) : canWrite ? (
+                      <button
+                        className="button button--ghost"
+                        onClick={() => setConfirmDeleteId(template.templateId)}
+                        type="button"
+                      >
+                        Delete
+                      </button>
+                    ) : null}
+                  </div>
+
+                  {deleteMutation.isError && confirmDeleteId === template.templateId ? (
+                    <div className="designer-banner designer-banner--error" role="alert">
+                      <strong>Delete failed.</strong>
+                      <span>Could not delete the template. Please try again.</span>
+                    </div>
+                  ) : null}
+                </div>
+              ))}
+            </div>
+          </section>
+        ) : (
+          <EmptyState
+            title="No templates yet"
+            message={
+              canWrite
+                ? 'Create a template to define reusable field sets for enrollment forms.'
+                : 'No form templates have been created for this tenant yet.'
+            }
+            actionLabel={canWrite ? 'Create template' : undefined}
+            onAction={canWrite ? () => navigate('/org/form-templates/new') : undefined}
+          />
+        )
+      ) : null}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

Adds the form scheme template library to the org portal. Editors can create and manage named reusable field sets, and when opening the form designer for a course with no existing schema, they're offered the option to pre-populate the editor from a template.

Depends on: bluewuxi/OnlineForms#110 (backend API)

## Changes

| File | Change |
|---|---|
| `src/lib/api/types.ts` | `FormTemplate`, `FormTemplateCreatePayload`, `FormTemplateUpdatePayload` types |
| `src/lib/api/org.ts` | `listFormTemplates`, `getFormTemplate`, `createFormTemplate`, `updateFormTemplate`, `deleteFormTemplate` |
| `src/pages/org/FormTemplatesPage.tsx` | New — template library list page at `/org/form-templates` |
| `src/pages/org/FormTemplateEditorPage.tsx` | New — create/edit page at `/org/form-templates/:templateId` with full field editor |
| `src/app/routes.tsx` | Routes for `/org/form-templates` and `/org/form-templates/:templateId` |
| `src/components/layout/OrgSidebar.tsx` | "Form Templates" nav link after Courses |
| `src/pages/org/FormDesignerPage.tsx` | "Start from template" banner for new course schemas |

## UX flow

1. **Manage templates**: sidebar → Form Templates → create/edit/delete (editor/admin only; viewer sees read-only list)
2. **Apply template**: open Form Designer for a new course → banner appears with template dropdown → select + Apply → fields pre-populate → user edits and saves normally via existing `upsertFormSchema`
3. **Skip**: click Skip to use the default enrollment fields instead

## Test plan

- [ ] `/org/form-templates` renders empty state for new tenant
- [ ] Create a template → redirected to edit URL → appears in list
- [ ] Edit template fields, save → success banner, list reflects update
- [ ] Delete template → inline confirm → removed from list
- [ ] `org_viewer` role: Create/Edit/Delete affordances hidden; list still visible
- [ ] Form designer for a **new** course schema → template banner appears when templates exist
- [ ] Apply a template → fields populate from template; original template unchanged
- [ ] Skip → default enrollment fields used
- [ ] Form designer for a course with an **existing** schema → no template banner
- [ ] TypeScript: `tsc --noEmit` clean ✓
- [ ] Tests: 54/54 pass ✓
- [ ] Lint: clean ✓

Closes #97, #98, #99, #100

🤖 Generated with [Claude Code](https://claude.com/claude-code)