### PR TITLE
fix: move selectedField declaration before selectedFieldIdError in FormDesignerPage

### DIFF
--- a/src/pages/org/FormDesignerPage.tsx
+++ b/src/pages/org/FormDesignerPage.tsx
@@ -168,13 +168,14 @@ function FormDesignerEditor({
   const hasUnsavedChanges =
     JSON.stringify(initialPayload) !== JSON.stringify(draftPayload)
   const hasInvalidFieldIds = editableFields.some((f) => !isValidFieldId(f.fieldId))
+
+  const selectedField =
+    editableFields.find((field) => field.fieldId === selectedFieldId) ?? null
+
   const selectedFieldIdError =
     selectedField && !isValidFieldId(selectedField.fieldId)
       ? 'Must start with a lowercase letter, then lowercase letters, digits, or underscores only (e.g. first_name). Max 64 chars.'
       : null
-
-  const selectedField =
-    editableFields.find((field) => field.fieldId === selectedFieldId) ?? null
 
   const saveMutation = useMutation<
     FormSchemaUpsertResponse,


### PR DESCRIPTION
## Summary

Fixes a TypeScript build error introduced when inline Field ID validation was added to `FormDesignerPage`.

`selectedFieldIdError` was computed before `selectedField` was declared, causing:

```
error TS2448: Block-scoped variable 'selectedField' used before its declaration.
error TS2454: Variable 'selectedField' is used before being assigned.
```

## Fix

Moved `selectedField` declaration above `selectedFieldIdError` so the dependency order is correct. The same ordering was already correct in `FormTemplateEditorPage.tsx`.

## Test plan

- [ ] `tsc -b` passes with no errors ✓
- [ ] Frontend build completes successfully
- [ ] Field ID validation still works in FormDesignerPage

🤖 Generated with [Claude Code](https://claude.com/claude-code)