### PR TITLE
feat: course variants UI

### DIFF
--- a/src/features/courses/VariantEditorCard.tsx
+++ b/src/features/courses/VariantEditorCard.tsx
@@ -1,0 +1,320 @@
+import { type FormEvent, useState } from 'react'
+import type {
+  CourseVariant,
+  CourseVariantCreatePayload,
+  CourseVariantUpdatePayload,
+  DeliveryMode,
+} from '../../lib/api/types'
+
+type VariantFormState = {
+  title: string
+  description: string
+  startDate: string
+  endDate: string
+  deliveryMode: DeliveryMode
+  locationText: string
+  capacity: string
+  price: string
+  displayOrder: string
+}
+
+function toFormState(variant: CourseVariant): VariantFormState {
+  return {
+    title: variant.title,
+    description: variant.description ?? '',
+    startDate: variant.startDate,
+    endDate: variant.endDate,
+    deliveryMode: variant.deliveryMode,
+    locationText: variant.locationText ?? '',
+    capacity: variant.capacity?.toString() ?? '',
+    price: variant.price?.toString() ?? '',
+    displayOrder: variant.displayOrder.toString(),
+  }
+}
+
+const defaultFormState: VariantFormState = {
+  title: '',
+  description: '',
+  startDate: '',
+  endDate: '',
+  deliveryMode: 'online',
+  locationText: '',
+  capacity: '',
+  price: '',
+  displayOrder: '0',
+}
+
+function toPayload(state: VariantFormState): CourseVariantCreatePayload {
+  return {
+    title: state.title.trim(),
+    description: state.description.trim() || null,
+    startDate: state.startDate,
+    endDate: state.endDate,
+    deliveryMode: state.deliveryMode,
+    locationText: state.locationText.trim() || null,
+    capacity: state.capacity ? Number(state.capacity) : null,
+    price: state.price ? Number(state.price) : null,
+    displayOrder: state.displayOrder ? Number(state.displayOrder) : 0,
+  }
+}
+
+type NewVariantCardProps = {
+  onSave: (payload: CourseVariantCreatePayload) => void
+  onCancel: () => void
+  isSaving: boolean
+}
+
+export function NewVariantCard({ onSave, onCancel, isSaving }: NewVariantCardProps) {
+  const [draft, setDraft] = useState<VariantFormState>(defaultFormState)
+
+  function updateField<K extends keyof VariantFormState>(key: K, value: VariantFormState[K]) {
+    setDraft((current) => ({ ...current, [key]: value }))
+  }
+
+  function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    onSave(toPayload(draft))
+  }
+
+  return (
+    <div className="variant-editor-card variant-editor-card--new">
+      <form className="session-form" onSubmit={handleSubmit}>
+        <VariantFormFields draft={draft} updateField={updateField} disabled={isSaving} />
+        <div className="button-row">
+          <button type="submit" className="button button--primary" disabled={isSaving}>
+            {isSaving ? 'Saving…' : 'Add variant'}
+          </button>
+          <button type="button" className="button button--secondary" onClick={onCancel} disabled={isSaving}>
+            Cancel
+          </button>
+        </div>
+      </form>
+    </div>
+  )
+}
+
+type VariantEditorCardProps = {
+  variant: CourseVariant
+  onSave: (variantId: string, payload: CourseVariantUpdatePayload) => void
+  onDelete: (variantId: string) => void
+  isSaving: boolean
+  isDeleting: boolean
+  canWrite: boolean
+}
+
+export function VariantEditorCard({
+  variant,
+  onSave,
+  onDelete,
+  isSaving,
+  isDeleting,
+  canWrite,
+}: VariantEditorCardProps) {
+  const [isEditing, setIsEditing] = useState(false)
+  const [draft, setDraft] = useState<VariantFormState>(() => toFormState(variant))
+  const [confirmDelete, setConfirmDelete] = useState(false)
+
+  function updateField<K extends keyof VariantFormState>(key: K, value: VariantFormState[K]) {
+    setDraft((current) => ({ ...current, [key]: value }))
+  }
+
+  function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    onSave(variant.id, toPayload(draft))
+    setIsEditing(false)
+  }
+
+  function handleDeleteClick() {
+    if (confirmDelete) {
+      onDelete(variant.id)
+      setConfirmDelete(false)
+    } else {
+      setConfirmDelete(true)
+    }
+  }
+
+  if (isEditing) {
+    return (
+      <div className="variant-editor-card variant-editor-card--editing">
+        <form className="session-form" onSubmit={handleSubmit}>
+          <VariantFormFields draft={draft} updateField={updateField} disabled={isSaving} />
+          <div className="button-row">
+            <button type="submit" className="button button--primary" disabled={isSaving}>
+              {isSaving ? 'Saving…' : 'Save variant'}
+            </button>
+            <button
+              type="button"
+              className="button button--secondary"
+              onClick={() => {
+                setDraft(toFormState(variant))
+                setIsEditing(false)
+              }}
+              disabled={isSaving}
+            >
+              Cancel
+            </button>
+          </div>
+        </form>
+      </div>
+    )
+  }
+
+  return (
+    <div className="variant-editor-card">
+      <div className="variant-editor-card__header">
+        <div>
+          <strong>{variant.title}</strong>
+          <span className="variant-editor-card__meta">
+            {variant.startDate} – {variant.endDate} · {variant.deliveryMode}
+            {variant.locationText ? ` · ${variant.locationText}` : ''}
+          </span>
+        </div>
+        {canWrite ? (
+          <div className="button-row">
+            <button
+              type="button"
+              className="button button--secondary button--small"
+              onClick={() => {
+                setDraft(toFormState(variant))
+                setIsEditing(true)
+                setConfirmDelete(false)
+              }}
+            >
+              Edit
+            </button>
+            <button
+              type="button"
+              className={`button button--small ${confirmDelete ? 'button--danger' : 'button--secondary'}`}
+              onClick={handleDeleteClick}
+              disabled={isDeleting}
+            >
+              {isDeleting ? 'Deleting…' : confirmDelete ? 'Confirm delete' : 'Delete'}
+            </button>
+            {confirmDelete ? (
+              <button
+                type="button"
+                className="button button--secondary button--small"
+                onClick={() => setConfirmDelete(false)}
+              >
+                Cancel
+              </button>
+            ) : null}
+          </div>
+        ) : null}
+      </div>
+      {variant.description ? (
+        <p className="variant-editor-card__description">{variant.description}</p>
+      ) : null}
+    </div>
+  )
+}
+
+type VariantFormFieldsProps = {
+  draft: VariantFormState
+  updateField: <K extends keyof VariantFormState>(key: K, value: VariantFormState[K]) => void
+  disabled: boolean
+}
+
+function VariantFormFields({ draft, updateField, disabled }: VariantFormFieldsProps) {
+  return (
+    <>
+      <label className="session-form__field">
+        <span>Variant title</span>
+        <input
+          disabled={disabled}
+          onChange={(event) => updateField('title', event.target.value)}
+          placeholder="e.g. Morning Session, Online Option"
+          type="text"
+          value={draft.title}
+          required
+        />
+      </label>
+      <label className="session-form__field">
+        <span>Variant description (appended to course description)</span>
+        <textarea
+          className="designer-textarea"
+          disabled={disabled}
+          onChange={(event) => updateField('description', event.target.value)}
+          rows={3}
+          value={draft.description}
+        />
+      </label>
+      <div className="field-grid field-grid--course-dates">
+        <label className="session-form__field">
+          <span>Start date</span>
+          <input
+            disabled={disabled}
+            onChange={(event) => updateField('startDate', event.target.value)}
+            type="date"
+            value={draft.startDate}
+            required
+          />
+        </label>
+        <label className="session-form__field">
+          <span>End date</span>
+          <input
+            disabled={disabled}
+            onChange={(event) => updateField('endDate', event.target.value)}
+            type="date"
+            value={draft.endDate}
+            required
+          />
+        </label>
+      </div>
+      <label className="session-form__field">
+        <span>Delivery mode</span>
+        <select
+          disabled={disabled}
+          onChange={(event) => updateField('deliveryMode', event.target.value as DeliveryMode)}
+          value={draft.deliveryMode}
+        >
+          <option value="online">Online</option>
+          <option value="onsite">Onsite</option>
+          <option value="hybrid">Hybrid</option>
+        </select>
+      </label>
+      <label className="session-form__field">
+        <span>Location (for onsite / hybrid)</span>
+        <input
+          disabled={disabled}
+          onChange={(event) => updateField('locationText', event.target.value)}
+          type="text"
+          value={draft.locationText}
+        />
+      </label>
+      <div className="field-grid field-grid--course-dates">
+        <label className="session-form__field">
+          <span>Capacity</span>
+          <input
+            disabled={disabled}
+            min={1}
+            onChange={(event) => updateField('capacity', event.target.value)}
+            type="number"
+            value={draft.capacity}
+          />
+        </label>
+        <label className="session-form__field">
+          <span>Price (reserved — not yet active)</span>
+          <input
+            disabled
+            min={0}
+            onChange={(event) => updateField('price', event.target.value)}
+            placeholder="Reserved for future use"
+            type="number"
+            value={draft.price}
+          />
+        </label>
+        <label className="session-form__field">
+          <span>Display order</span>
+          <input
+            disabled={disabled}
+            min={0}
+            onChange={(event) => updateField('displayOrder', event.target.value)}
+            type="number"
+            value={draft.displayOrder}
+          />
+        </label>
+      </div>
+    </>
+  )
+}

--- a/src/features/courses/VariantsManager.tsx
+++ b/src/features/courses/VariantsManager.tsx
@@ -1,0 +1,156 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { useState } from 'react'
+import {
+  type ApiClientError,
+  createCourseVariant,
+  deleteCourseVariant,
+  listCourseVariants,
+  updateCourseVariant,
+  type CourseVariant,
+  type CourseVariantCreatePayload,
+  type CourseVariantUpdatePayload,
+  type OrgSessionHeaders,
+} from '../../lib/api'
+import { NewVariantCard, VariantEditorCard } from './VariantEditorCard'
+
+type VariantsManagerProps = {
+  courseId: string
+  session: OrgSessionHeaders
+  canWrite: boolean
+}
+
+export function VariantsManager({ courseId, session, canWrite }: VariantsManagerProps) {
+  const queryClient = useQueryClient()
+  const [showNewForm, setShowNewForm] = useState(false)
+  const [mutationError, setMutationError] = useState<string | null>(null)
+
+  const variantsQuery = useQuery({
+    queryKey: ['org-course-variants', session.tenantId, courseId],
+    queryFn: async () => {
+      const response = await listCourseVariants(session, courseId)
+      return response.data
+    },
+  })
+
+  const createMutation = useMutation<CourseVariant, ApiClientError, CourseVariantCreatePayload>({
+    mutationFn: async (payload) => {
+      const response = await createCourseVariant(session, courseId, payload)
+      return response.data
+    },
+    onSuccess: () => {
+      setShowNewForm(false)
+      setMutationError(null)
+      void queryClient.invalidateQueries({ queryKey: ['org-course-variants', session.tenantId, courseId] })
+      void queryClient.invalidateQueries({ queryKey: ['org-course', session.tenantId, courseId] })
+    },
+    onError: (error) => {
+      setMutationError(error.message || 'Failed to create variant.')
+    },
+  })
+
+  const updateMutation = useMutation<
+    CourseVariant,
+    ApiClientError,
+    { variantId: string; payload: CourseVariantUpdatePayload }
+  >({
+    mutationFn: async ({ variantId, payload }) => {
+      const response = await updateCourseVariant(session, courseId, variantId, payload)
+      return response.data
+    },
+    onSuccess: () => {
+      setMutationError(null)
+      void queryClient.invalidateQueries({ queryKey: ['org-course-variants', session.tenantId, courseId] })
+      void queryClient.invalidateQueries({ queryKey: ['org-course', session.tenantId, courseId] })
+    },
+    onError: (error) => {
+      setMutationError(error.message || 'Failed to update variant.')
+    },
+  })
+
+  const deleteMutation = useMutation<unknown, ApiClientError, string>({
+    mutationFn: async (variantId) => {
+      await deleteCourseVariant(session, courseId, variantId)
+    },
+    onSuccess: () => {
+      setMutationError(null)
+      void queryClient.invalidateQueries({ queryKey: ['org-course-variants', session.tenantId, courseId] })
+      void queryClient.invalidateQueries({ queryKey: ['org-course', session.tenantId, courseId] })
+    },
+    onError: (error) => {
+      setMutationError(error.message || 'Failed to delete variant.')
+    },
+  })
+
+  const variants = variantsQuery.data ?? []
+
+  return (
+    <section className="content-panel">
+      <div className="section-heading">
+        <p className="section-heading__eyebrow">Course variants</p>
+        <h2>Variant options</h2>
+      </div>
+      <p className="content-panel__body-copy">
+        Variants share this course's application form and quote. Each variant can have its own schedule, delivery mode,
+        and description (appended to the main course description on the public page).
+      </p>
+
+      {variantsQuery.isLoading ? (
+        <p>Loading variants…</p>
+      ) : null}
+
+      {variantsQuery.isError ? (
+        <p className="form-error">Failed to load variants.</p>
+      ) : null}
+
+      {mutationError ? (
+        <p className="form-error">{mutationError}</p>
+      ) : null}
+
+      {variants.length === 0 && !variantsQuery.isLoading ? (
+        <p className="content-panel__body-copy">
+          No variants yet. When at least one variant is added, applicants will be required to choose one before
+          submitting the enrollment form.
+        </p>
+      ) : null}
+
+      <div className="variants-list">
+        {variants.map((variant) => (
+          <VariantEditorCard
+            key={variant.id}
+            variant={variant}
+            onSave={(variantId, payload) => updateMutation.mutate({ variantId, payload })}
+            onDelete={(variantId) => deleteMutation.mutate(variantId)}
+            isSaving={updateMutation.isPending && updateMutation.variables?.variantId === variant.id}
+            isDeleting={deleteMutation.isPending && deleteMutation.variables === variant.id}
+            canWrite={canWrite}
+          />
+        ))}
+      </div>
+
+      {canWrite ? (
+        <div className="button-row" style={{ marginTop: '1rem' }}>
+          {showNewForm ? null : (
+            <button
+              type="button"
+              className="button button--secondary"
+              onClick={() => {
+                setShowNewForm(true)
+                setMutationError(null)
+              }}
+            >
+              + Add variant
+            </button>
+          )}
+        </div>
+      ) : null}
+
+      {showNewForm && canWrite ? (
+        <NewVariantCard
+          onSave={(payload) => createMutation.mutate(payload)}
+          onCancel={() => setShowNewForm(false)}
+          isSaving={createMutation.isPending}
+        />
+      ) : null}
+    </section>
+  )
+}

--- a/src/features/enrollment/FormPreview.tsx
+++ b/src/features/enrollment/FormPreview.tsx
@@ -23,6 +23,8 @@ type FormPreviewProps = {
   courseTitle?: string
   enrollmentStatus?: 'upcoming' | 'open' | 'closed'
   formAvailable?: boolean
+  variantId?: string | null
+  variantRequired?: boolean
 }
 
 // FS-01: Default max lengths aligned with backend enforcement (BS-04).
@@ -140,6 +142,8 @@ export function FormPreview({
   courseTitle,
   enrollmentStatus,
   formAvailable,
+  variantId,
+  variantRequired,
 }: FormPreviewProps) {
   const {
     register,
@@ -186,6 +190,7 @@ export function FormPreview({
         formVersion: schema.version,
         answers: normalizeEnrollmentAnswers(values),
         meta: createEnrollmentMeta(),
+        variantId: variantId ?? null,
         // FS-04: Include CAPTCHA token from Turnstile widget when enabled.
         _captchaToken:
           TURNSTILE_ENABLED && TURNSTILE_SITE_KEY
@@ -251,6 +256,18 @@ export function FormPreview({
           <Link className="button button--secondary" to={`/${tenantCode}/courses`}>
             Back to course list
           </Link>
+        </div>
+      </section>
+    )
+  }
+
+  if (variantRequired && !variantId) {
+    return (
+      <section className="content-panel enrollment-form-shell">
+        <div className="enrollment-form-shell__state-card">
+          <span className="enrollment-form-shell__state-icon">○</span>
+          <strong>Select an option above to continue</strong>
+          <p>Choose your preferred variant to reveal the application form.</p>
         </div>
       </section>
     )

--- a/src/features/enrollment/VariantSelector.tsx
+++ b/src/features/enrollment/VariantSelector.tsx
@@ -1,0 +1,61 @@
+import type { CourseVariant } from '../../lib/api/types'
+
+type VariantSelectorProps = {
+  variants: CourseVariant[]
+  selectedVariantId: string | null
+  onSelect: (variantId: string) => void
+}
+
+function formatDate(value?: string | null) {
+  if (!value) return 'Not specified'
+  const date = new Date(value)
+  return Number.isNaN(date.getTime()) ? value : date.toLocaleDateString()
+}
+
+export function VariantSelector({ variants, selectedVariantId, onSelect }: VariantSelectorProps) {
+  if (variants.length === 0) return null
+
+  return (
+    <section className="content-panel">
+      <div className="section-heading">
+        <p className="section-heading__eyebrow">Step 1 of 2</p>
+        <h2>Choose your preferred option</h2>
+      </div>
+      <p className="content-panel__body-copy">
+        This course is offered in multiple variants. Select the option that suits you before completing the application
+        form below.
+      </p>
+      <div className="variant-selector">
+        {variants
+          .slice()
+          .sort((a, b) => a.displayOrder - b.displayOrder)
+          .map((variant) => {
+            const isSelected = variant.id === selectedVariantId
+            return (
+              <button
+                key={variant.id}
+                type="button"
+                className={`variant-selector__card${isSelected ? ' variant-selector__card--selected' : ''}`}
+                onClick={() => onSelect(variant.id)}
+                aria-pressed={isSelected}
+              >
+                <div className="variant-selector__card-header">
+                  <strong className="variant-selector__title">{variant.title}</strong>
+                  {isSelected ? <span className="variant-selector__badge">Selected</span> : null}
+                </div>
+                <div className="variant-selector__meta">
+                  <span>{formatDate(variant.startDate)} – {formatDate(variant.endDate)}</span>
+                  <span>{variant.deliveryMode}</span>
+                  {variant.locationText ? <span>{variant.locationText}</span> : null}
+                  {variant.capacity ? <span>Capacity: {variant.capacity}</span> : null}
+                </div>
+                {variant.description ? (
+                  <p className="variant-selector__description">{variant.description}</p>
+                ) : null}
+              </button>
+            )
+          })}
+      </div>
+    </section>
+  )
+}

--- a/src/lib/api/org.ts
+++ b/src/lib/api/org.ts
@@ -5,6 +5,9 @@ import type {
   BrandingSettings,
   BrandingUpdateResponse,
   CourseStatus,
+  CourseVariant,
+  CourseVariantCreatePayload,
+  CourseVariantUpdatePayload,
   CursorPage,
   DeliveryMode,
   FormField,
@@ -13,7 +16,7 @@ import type {
   OrgAsset,
   OrgCourseCreateResponse,
   OrgCourseStatusResponse,
-  OrgCourse,
+  OrgCourseWithVariants,
   OrgCourseSummary,
   OrgCourseUpdatePayload,
   OrgCourseUpsertPayload,
@@ -114,6 +117,7 @@ type BackendOrgCourse = {
   activeFormVersion?: number | null
   createdAt: string
   updatedAt: string
+  variants?: CourseVariant[]
 }
 
 type BackendInternalTenant = {
@@ -229,7 +233,7 @@ function mapFormSchema(schema: BackendFormSchema) {
   }
 }
 
-function mapOrgCourse(course: BackendOrgCourse): OrgCourse {
+function mapOrgCourse(course: BackendOrgCourse): OrgCourseWithVariants {
   return {
     id: course.id,
     title: course.title,
@@ -251,6 +255,7 @@ function mapOrgCourse(course: BackendOrgCourse): OrgCourse {
     activeFormVersion: course.activeFormVersion,
     createdAt: course.createdAt,
     updatedAt: course.updatedAt,
+    variants: course.variants ?? [],
   }
 }
 
@@ -376,7 +381,7 @@ export function getCourse(session: OrgSessionHeaders, courseId: string) {
     session,
   }).then((response) => ({
     ...response,
-    data: mapOrgCourse(response.data.data),
+    data: mapOrgCourse(response.data.data) as OrgCourseWithVariants,
   }))
 }
 
@@ -431,6 +436,61 @@ export function archiveCourse(session: OrgSessionHeaders, courseId: string) {
     ...response,
     data: response.data.data,
   }))
+}
+
+export function listCourseVariants(session: OrgSessionHeaders, courseId: string) {
+  return apiRequest<BackendItemEnvelope<CourseVariant[]>>({
+    path: `/org/courses/${courseId}/variants`,
+    session,
+  }).then((response) => ({
+    ...response,
+    data: response.data.data,
+  }))
+}
+
+export function createCourseVariant(
+  session: OrgSessionHeaders,
+  courseId: string,
+  payload: CourseVariantCreatePayload,
+) {
+  return apiRequest<BackendItemEnvelope<CourseVariant>>({
+    path: `/org/courses/${courseId}/variants`,
+    method: 'POST',
+    session,
+    body: payload,
+  }).then((response) => ({
+    ...response,
+    data: response.data.data,
+  }))
+}
+
+export function updateCourseVariant(
+  session: OrgSessionHeaders,
+  courseId: string,
+  variantId: string,
+  payload: CourseVariantUpdatePayload,
+) {
+  return apiRequest<BackendItemEnvelope<CourseVariant>>({
+    path: `/org/courses/${courseId}/variants/${variantId}`,
+    method: 'PATCH',
+    session,
+    body: payload,
+  }).then((response) => ({
+    ...response,
+    data: response.data.data,
+  }))
+}
+
+export function deleteCourseVariant(
+  session: OrgSessionHeaders,
+  courseId: string,
+  variantId: string,
+) {
+  return apiRequest<Record<string, never>>({
+    path: `/org/courses/${courseId}/variants/${variantId}`,
+    method: 'DELETE',
+    session,
+  })
 }
 
 export function listSubmissions(

--- a/src/lib/api/public.ts
+++ b/src/lib/api/public.ts
@@ -3,6 +3,7 @@ import { ApiClientError, apiRequest, createIdempotencyKey } from './http'
 import type {
   Course,
   CourseListItem,
+  CourseVariant,
   CursorPage,
   EnrollmentPayload,
   EnrollmentResponse,
@@ -50,6 +51,7 @@ type BackendPublicCourse = BackendPublicCourseListItem & {
   formAvailable?: boolean
   formVersion?: number | null
   formSchema?: FormSchema | null
+  variants?: CourseVariant[]
 }
 
 type BackendTenantDirectoryItem = {
@@ -175,6 +177,7 @@ function mapCourse(course: BackendPublicCourse): Course {
     formAvailable: course.formAvailable ?? false,
     formVersion: course.formVersion ?? null,
     formSchema: course.formSchema ?? undefined,
+    variants: course.variants ?? [],
   }
 }
 

--- a/src/lib/api/types.ts
+++ b/src/lib/api/types.ts
@@ -72,7 +72,39 @@ export type Course = CourseListItem & {
   formAvailable?: boolean
   formVersion?: number | null
   formSchema?: FormSchema | Record<string, unknown>
+  variants?: CourseVariant[]
 }
+
+export type CourseVariant = {
+  id: string
+  courseId?: string
+  tenantId?: string
+  title: string
+  description?: string | null
+  startDate: string
+  endDate: string
+  deliveryMode: DeliveryMode
+  locationText?: string | null
+  capacity?: number | null
+  price?: number | null
+  displayOrder: number
+  createdAt?: string
+  updatedAt?: string
+}
+
+export type CourseVariantCreatePayload = {
+  title: string
+  description?: string | null
+  startDate: string
+  endDate: string
+  deliveryMode: DeliveryMode
+  locationText?: string | null
+  capacity?: number | null
+  price?: number | null
+  displayOrder?: number
+}
+
+export type CourseVariantUpdatePayload = Partial<CourseVariantCreatePayload>
 
 export type OrgCourse = {
   id: string
@@ -95,6 +127,10 @@ export type OrgCourse = {
   activeFormVersion?: number | null
   createdAt: string
   updatedAt: string
+}
+
+export type OrgCourseWithVariants = OrgCourse & {
+  variants: CourseVariant[]
 }
 
 export type OrgCourseSummary = Pick<
@@ -223,6 +259,7 @@ export type EnrollmentPayload = {
     locale?: string
     timezone?: string
   }
+  variantId?: string | null
   /** FS-04: Cloudflare Turnstile token for server-side CAPTCHA verification. */
   _captchaToken?: string
   /** FS-03: Honeypot flag — true if the hidden honeypot field was filled (bot indicator). */

--- a/src/pages/org/CourseEditorPage.tsx
+++ b/src/pages/org/CourseEditorPage.tsx
@@ -5,6 +5,7 @@ import { ErrorState } from '../../components/feedback/ErrorState'
 import { LoadingState } from '../../components/feedback/LoadingState'
 import { HtmlEditorField } from '../../components/forms/HtmlEditorField'
 import { PageHero } from '../../components/layout/PageHero'
+import { VariantsManager } from '../../features/courses/VariantsManager'
 import { useCanWrite } from '../../features/org-session/useCanWrite'
 import { useOrgSession } from '../../features/org-session/useOrgSession'
 import {
@@ -581,6 +582,10 @@ export function CourseEditorPage() {
           isCreateMode={isCreateMode}
           session={session}
         />
+      ) : null}
+
+      {!isCreateMode && courseId && session && !courseQuery.isLoading && !courseQuery.isError ? (
+        <VariantsManager courseId={courseId} session={session} canWrite={canWrite} />
       ) : null}
     </div>
   )

--- a/src/pages/org/FormDesignerPage.tsx
+++ b/src/pages/org/FormDesignerPage.tsx
@@ -168,13 +168,14 @@ function FormDesignerEditor({
   const hasUnsavedChanges =
     JSON.stringify(initialPayload) !== JSON.stringify(draftPayload)
   const hasInvalidFieldIds = editableFields.some((f) => !isValidFieldId(f.fieldId))
+
+  const selectedField =
+    editableFields.find((field) => field.fieldId === selectedFieldId) ?? null
+
   const selectedFieldIdError =
     selectedField && !isValidFieldId(selectedField.fieldId)
       ? 'Must start with a lowercase letter, then lowercase letters, digits, or underscores only (e.g. first_name). Max 64 chars.'
       : null
-
-  const selectedField =
-    editableFields.find((field) => field.fieldId === selectedFieldId) ?? null
 
   const saveMutation = useMutation<
     FormSchemaUpsertResponse,

--- a/src/pages/public/CourseDetailPage.tsx
+++ b/src/pages/public/CourseDetailPage.tsx
@@ -1,4 +1,5 @@
 import { useQuery } from '@tanstack/react-query'
+import { useState } from 'react'
 import { Link, useParams } from 'react-router-dom'
 import { RichText } from '../../components/content/RichText'
 import { ErrorState } from '../../components/feedback/ErrorState'
@@ -6,6 +7,7 @@ import { LoadingState } from '../../components/feedback/LoadingState'
 import { PageHero } from '../../components/layout/PageHero'
 import { FormPreview } from '../../features/enrollment/FormPreview'
 import { parseFormSchema } from '../../features/enrollment/formSchema'
+import { VariantSelector } from '../../features/enrollment/VariantSelector'
 import { getPublicCourse } from '../../lib/api'
 import { normalizeTenantCode } from '../../lib/routing/tenantCode'
 
@@ -35,6 +37,8 @@ function normalizeStatusLabel(value?: string) {
 export function CourseDetailPage() {
   const { tenantCode: tenantCodeParam, courseId = '' } = useParams()
   const tenantCode = normalizeTenantCode(tenantCodeParam ?? '')
+  const [selectedVariantId, setSelectedVariantId] = useState<string | null>(null)
+
   const courseQuery = useQuery({
     queryKey: ['public-course', tenantCode, courseId],
     queryFn: async () => {
@@ -48,6 +52,12 @@ export function CourseDetailPage() {
     courseQuery.data?.formSchema,
     courseQuery.data?.formVersion,
   )
+
+  const variants = courseQuery.data?.variants ?? []
+  const hasVariants = variants.length > 0
+  const selectedVariant = hasVariants
+    ? variants.find((v) => v.id === selectedVariantId) ?? null
+    : null
 
   return (
     <div className="page-stack">
@@ -133,17 +143,32 @@ export function CourseDetailPage() {
             </div>
           </section>
 
-          {courseQuery.data.description ? (
+          {courseQuery.data.description || selectedVariant?.description ? (
             <section className="content-panel">
               <div className="section-heading">
                 <p className="section-heading__eyebrow">Course overview</p>
                 <h2>What this course covers</h2>
               </div>
-              <RichText
-                html={courseQuery.data.description}
-                className="rich-text content-panel__body-copy content-panel__body-copy--wide"
-              />
+              {courseQuery.data.description ? (
+                <RichText
+                  html={courseQuery.data.description}
+                  className="rich-text content-panel__body-copy content-panel__body-copy--wide"
+                />
+              ) : null}
+              {selectedVariant?.description ? (
+                <p className="content-panel__body-copy" style={{ marginTop: '1rem' }}>
+                  {selectedVariant.description}
+                </p>
+              ) : null}
             </section>
+          ) : null}
+
+          {hasVariants ? (
+            <VariantSelector
+              variants={variants}
+              selectedVariantId={selectedVariantId}
+              onSelect={setSelectedVariantId}
+            />
           ) : null}
 
           <FormPreview
@@ -153,6 +178,8 @@ export function CourseDetailPage() {
             formAvailable={courseQuery.data.formAvailable}
             schema={formSchema}
             tenantCode={tenantCode}
+            variantId={selectedVariantId}
+            variantRequired={hasVariants}
           />
         </>
       ) : null}


### PR DESCRIPTION
## Summary

- Variant management panel in the org course editor (list, create, edit, delete variants per course)
- Variant selector on the public course detail page — required selection before the enrollment form appears
- Selected variant description appended to the course description
- `variantId` included in the enrollment submission payload

## Changes

**Types & API client**
- `CourseVariant`, `CourseVariantCreatePayload`, `CourseVariantUpdatePayload` types added
- `OrgCourseWithVariants = OrgCourse & { variants: CourseVariant[] }`
- `variantId?: string | null` added to `EnrollmentPayload`
- `listCourseVariants`, `createCourseVariant`, `updateCourseVariant`, `deleteCourseVariant` functions added to `org.ts`
- Public course mapper updated to include `variants` array

**Org admin**
- `VariantEditorCard.tsx` — inline create/edit/delete card for a single variant
- `VariantsManager.tsx` — list of cards with TanStack Query CRUD, empty state, "Add variant" button
- `CourseEditorPage.tsx` — `VariantsManager` section below main form (existing courses only)

**Public enrollment**
- `VariantSelector.tsx` — card grid of variants with selection state
- `CourseDetailPage.tsx` — renders `VariantSelector` when variants exist; tracks `selectedVariantId`; appends selected variant description
- `FormPreview.tsx` — accepts `variantId` / `variantRequired`; guards form until variant selected; sends `variantId` in payload

## Test plan

- [x] `npm run lint` — no errors
- [x] `tsc --noEmit` — no errors
- [ ] Create a course with 2 variants → verify variant cards render in editor, can edit/delete
- [ ] Publish course → open public detail page → verify variant selector appears, selecting a variant appends its description and reveals the form
- [ ] Submit enrollment → verify `variantId` on submission
- [ ] Regression: course without variants → no selector, form renders immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)