### PR TITLE
fix: Stripe round-1 cleanup (pricing mode, variant dates, payment settings)

### DIFF
--- a/src/app/routes.tsx
+++ b/src/app/routes.tsx
@@ -14,6 +14,7 @@ import { FormDesignerPage } from '../pages/org/FormDesignerPage'
 import { FormTemplatesPage } from '../pages/org/FormTemplatesPage'
 import { FormTemplateEditorPage } from '../pages/org/FormTemplateEditorPage'
 import { OrgSettingsPage } from '../pages/org/OrgSettingsPage'
+import { PaymentSettingsPage } from '../pages/org/PaymentSettingsPage'
 import { AcceptInvitePage } from '../pages/org/AcceptInvitePage'
 import { TeamPage } from '../pages/org/TeamPage'
 import { InternalHomePage } from '../pages/internal/InternalHomePage'
@@ -158,6 +159,10 @@ export const appRoutes: RouteObject[] = [
               {
                 path: 'branding',
                 element: <BrandingPage />,
+              },
+              {
+                path: 'payment-settings',
+                element: <PaymentSettingsPage />,
               },
               {
                 path: 'courses/:courseId/form',

--- a/src/components/layout/OrgSidebar.tsx
+++ b/src/components/layout/OrgSidebar.tsx
@@ -11,6 +11,7 @@ const navItems = [
   { to: '/org/submissions', label: 'Submissions' },
   { to: '/org/team', label: 'Users' },
   { to: '/org/branding', label: 'Branding' },
+  { to: '/org/payment-settings', label: 'Payment Settings' },
   { to: '/org/audit', label: 'Audit' },
   { to: '/org/settings', label: 'Settings' },
 ]

--- a/src/features/courses/VariantEditorCard.tsx
+++ b/src/features/courses/VariantEditorCard.tsx
@@ -9,8 +9,6 @@ import type {
 type VariantFormState = {
   title: string
   description: string
-  startDate: string
-  endDate: string
   deliveryMode: DeliveryMode
   locationText: string
   capacity: string
@@ -22,8 +20,6 @@ function toFormState(variant: CourseVariant): VariantFormState {
   return {
     title: variant.title,
     description: variant.description ?? '',
-    startDate: variant.startDate,
-    endDate: variant.endDate,
     deliveryMode: variant.deliveryMode,
     locationText: variant.locationText ?? '',
     capacity: variant.capacity?.toString() ?? '',
@@ -35,8 +31,6 @@ function toFormState(variant: CourseVariant): VariantFormState {
 const defaultFormState: VariantFormState = {
   title: '',
   description: '',
-  startDate: '',
-  endDate: '',
   deliveryMode: 'online',
   locationText: '',
   capacity: '',
@@ -48,8 +42,6 @@ function toPayload(state: VariantFormState): CourseVariantCreatePayload {
   return {
     title: state.title.trim(),
     description: state.description.trim() || null,
-    startDate: state.startDate,
-    endDate: state.endDate,
     deliveryMode: state.deliveryMode,
     locationText: state.locationText.trim() || null,
     capacity: state.capacity ? Number(state.capacity) : null,
@@ -165,7 +157,7 @@ export function VariantEditorCard({
         <div>
           <strong>{variant.title}</strong>
           <span className="variant-editor-card__meta">
-            {variant.startDate} – {variant.endDate} · {variant.deliveryMode}
+            {variant.deliveryMode}
             {variant.locationText ? ` · ${variant.locationText}` : ''}
           </span>
         </div>
@@ -239,28 +231,6 @@ function VariantFormFields({ draft, updateField, disabled }: VariantFormFieldsPr
           value={draft.description}
         />
       </label>
-      <div className="field-grid field-grid--course-dates">
-        <label className="session-form__field">
-          <span>Start date</span>
-          <input
-            disabled={disabled}
-            onChange={(event) => updateField('startDate', event.target.value)}
-            type="date"
-            value={draft.startDate}
-            required
-          />
-        </label>
-        <label className="session-form__field">
-          <span>End date</span>
-          <input
-            disabled={disabled}
-            onChange={(event) => updateField('endDate', event.target.value)}
-            type="date"
-            value={draft.endDate}
-            required
-          />
-        </label>
-      </div>
       <label className="session-form__field">
         <span>Delivery mode</span>
         <select
@@ -294,12 +264,12 @@ function VariantFormFields({ draft, updateField, disabled }: VariantFormFieldsPr
           />
         </label>
         <label className="session-form__field">
-          <span>Price (reserved — not yet active)</span>
+          <span>Price (in cents)</span>
           <input
-            disabled
+            disabled={disabled}
             min={0}
             onChange={(event) => updateField('price', event.target.value)}
-            placeholder="Reserved for future use"
+            placeholder="e.g. 5000 for $50.00"
             type="number"
             value={draft.price}
           />

--- a/src/features/enrollment/VariantSelector.tsx
+++ b/src/features/enrollment/VariantSelector.tsx
@@ -20,12 +20,6 @@ function formatPrice(amount: number, currency?: string | null): string {
   }
 }
 
-function formatDate(value?: string | null) {
-  if (!value) return 'Not specified'
-  const date = new Date(value)
-  return Number.isNaN(date.getTime()) ? value : date.toLocaleDateString()
-}
-
 export function VariantSelector({ variants, selectedVariantId, onSelect, currency }: VariantSelectorProps) {
   if (variants.length === 0) return null
 
@@ -69,7 +63,6 @@ export function VariantSelector({ variants, selectedVariantId, onSelect, currenc
                   </div>
                 </div>
                 <div className="variant-selector__meta">
-                  <span>{formatDate(variant.startDate)} – {formatDate(variant.endDate)}</span>
                   <span>{variant.deliveryMode}</span>
                   {variant.locationText ? <span>{variant.locationText}</span> : null}
                   {variant.capacity ? <span>Capacity: {variant.capacity}</span> : null}

--- a/src/lib/api/org.ts
+++ b/src/lib/api/org.ts
@@ -44,6 +44,8 @@ import type {
   FormTemplate,
   FormTemplateCreatePayload,
   FormTemplateUpdatePayload,
+  PaymentSettings,
+  PaymentSettingsUpdatePayload,
 } from './types'
 
 type BackendPage = {
@@ -630,6 +632,31 @@ export function getBranding(session: OrgSessionHeaders) {
   return apiRequest<BackendItemEnvelope<BrandingSettings>>({
     path: '/org/branding',
     session,
+  }).then((response) => ({
+    ...response,
+    data: response.data.data,
+  }))
+}
+
+export function getPaymentSettings(session: OrgSessionHeaders) {
+  return apiRequest<BackendItemEnvelope<PaymentSettings>>({
+    path: '/org/payment-settings',
+    session,
+  }).then((response) => ({
+    ...response,
+    data: response.data.data,
+  }))
+}
+
+export function updatePaymentSettings(
+  session: OrgSessionHeaders,
+  payload: PaymentSettingsUpdatePayload,
+) {
+  return apiRequest<BackendItemEnvelope<PaymentSettings>>({
+    path: '/org/payment-settings',
+    method: 'PATCH',
+    session,
+    body: payload,
   }).then((response) => ({
     ...response,
     data: response.data.data,

--- a/src/lib/api/types.ts
+++ b/src/lib/api/types.ts
@@ -31,7 +31,7 @@ export type OrgSessionHeaders = {
 }
 
 export type DeliveryMode = 'online' | 'onsite' | 'hybrid'
-export type PricingMode = 'free' | 'paid_placeholder'
+export type PricingMode = 'free' | 'paid'
 export type CourseStatus = 'draft' | 'published' | 'archived'
 
 export type ApiRequestOptions = {
@@ -81,8 +81,6 @@ export type CourseVariant = {
   tenantId?: string
   title: string
   description?: string | null
-  startDate: string
-  endDate: string
   deliveryMode: DeliveryMode
   locationText?: string | null
   capacity?: number | null
@@ -95,8 +93,6 @@ export type CourseVariant = {
 export type CourseVariantCreatePayload = {
   title: string
   description?: string | null
-  startDate: string
-  endDate: string
   deliveryMode: DeliveryMode
   locationText?: string | null
   capacity?: number | null
@@ -363,7 +359,6 @@ export type BrandingUpdatePayload = {
   logoAssetId?: string | null
   description?: string | null
   homePageContent?: string | null
-  currency?: string | null
 }
 
 export type BrandingSettings = {
@@ -371,13 +366,22 @@ export type BrandingSettings = {
   displayName?: string
   description?: string | null
   homePageContent?: string | null
-  currency?: string | null
   logoAssetId: string | null
   logoUrl?: string | null
   updatedAt?: string
 }
 
 export type BrandingUpdateResponse = BrandingSettings
+
+export type PaymentSettings = {
+  currency?: string | null
+  invoiceBusinessName?: string | null
+}
+
+export type PaymentSettingsUpdatePayload = {
+  currency?: string | null
+  invoiceBusinessName?: string | null
+}
 
 export type TenantDirectoryItem = {
   tenantId: string

--- a/src/pages/org/BrandingPage.tsx
+++ b/src/pages/org/BrandingPage.tsx
@@ -104,16 +104,10 @@ export function BrandingPage() {
     },
   })
 
-  const [currencyDraft, setCurrencyDraft] = useState('')
-  const [currencyDirty, setCurrencyDirty] = useState(false)
-  const effectiveCurrencyDraft = currencyDirty
-    ? currencyDraft
-    : currentBranding?.currency || ''
-
   const brandingMutation = useMutation<
     BrandingUpdateResponse,
     ApiClientError | Error,
-    { logoAssetId?: string | null; description?: string | null; currency?: string | null }
+    { logoAssetId?: string | null; description?: string | null }
   >({
     mutationFn: async (payload) => {
       if (!session) {
@@ -127,8 +121,6 @@ export function BrandingPage() {
       setBrandingResult(result)
       setDescriptionDraft(result.description || '')
       setDescriptionDirty(false)
-      setCurrencyDraft(result.currency || '')
-      setCurrencyDirty(false)
       brandingQuery.refetch()
     },
   })
@@ -179,10 +171,6 @@ export function BrandingPage() {
             <span>Description status</span>
             <strong>{effectiveDescriptionDraft.trim() ? 'Configured' : 'Missing'}</strong>
           </div>
-          <div className="field-card">
-            <span>Payment currency</span>
-            <strong>{currentBranding?.currency?.toUpperCase() || 'Not set'}</strong>
-          </div>
         </div>
         <div className="button-row">
           <StatusChip tone={currentBranding?.logoAssetId ? 'info' : 'warning'}>
@@ -210,59 +198,6 @@ export function BrandingPage() {
             <strong>You have read-only access to this tenant.</strong>
             <span>Contact an Org Admin to make changes.</span>
           </div>
-        </section>
-      ) : null}
-
-      {canWrite ? (
-        <section className="content-panel">
-          <SectionHeader
-            eyebrow="Payment settings"
-            title="Payment currency"
-            description="Set the currency used for paid course enrollments. Must be a 3-letter ISO 4217 code (e.g. AUD, USD, GBP). Leave blank to disable paid enrollments."
-          />
-          <form
-            className="session-form"
-            onSubmit={(event) => {
-              event.preventDefault()
-              brandingMutation.mutate({
-                currency: effectiveCurrencyDraft.trim().toLowerCase() || null,
-              })
-            }}
-          >
-            <label className="session-form__field">
-              <span>Currency code</span>
-              <select
-                value={effectiveCurrencyDraft.toUpperCase()}
-                onChange={(e) => {
-                  setCurrencyDirty(true)
-                  setCurrencyDraft(e.target.value.toLowerCase())
-                }}
-              >
-                <option value="">Not set (free courses only)</option>
-                <option value="AUD">AUD — Australian Dollar</option>
-                <option value="USD">USD — US Dollar</option>
-                <option value="GBP">GBP — British Pound</option>
-                <option value="NZD">NZD — New Zealand Dollar</option>
-                <option value="CAD">CAD — Canadian Dollar</option>
-                <option value="EUR">EUR — Euro</option>
-                <option value="SGD">SGD — Singapore Dollar</option>
-              </select>
-            </label>
-            <div className="session-form__actions">
-              <button
-                className="button button--primary"
-                disabled={brandingMutation.isPending}
-                type="submit"
-              >
-                {brandingMutation.isPending ? 'Saving...' : 'Save currency'}
-              </button>
-              {brandingMutation.isError ? (
-                <p className="session-form__error">
-                  Failed to save currency setting.
-                </p>
-              ) : null}
-            </div>
-          </form>
         </section>
       ) : null}
 

--- a/src/pages/org/CourseEditorPage.tsx
+++ b/src/pages/org/CourseEditorPage.tsx
@@ -395,7 +395,7 @@ function CourseEditorForm({
               value={draft.pricingMode}
             >
               <option value="free">Free</option>
-              <option value="paid_placeholder">Paid placeholder</option>
+              <option value="paid">Paid</option>
             </select>
           </label>
           <label className="session-form__field session-form__field--wide">

--- a/src/pages/org/PaymentSettingsPage.tsx
+++ b/src/pages/org/PaymentSettingsPage.tsx
@@ -1,0 +1,215 @@
+import { useMutation, useQuery } from '@tanstack/react-query'
+import { useState } from 'react'
+import { ErrorState } from '../../components/feedback/ErrorState'
+import { LoadingState } from '../../components/feedback/LoadingState'
+import { PageHero } from '../../components/layout/PageHero'
+import { SectionHeader } from '../../components/layout/SectionHeader'
+import { useCanWrite } from '../../features/org-session/useCanWrite'
+import { useOrgSession } from '../../features/org-session/useOrgSession'
+import {
+  ApiClientError,
+  getPaymentSettings,
+  updatePaymentSettings,
+  type PaymentSettings,
+} from '../../lib/api'
+
+export function PaymentSettingsPage() {
+  const { session } = useOrgSession()
+  const canWrite = useCanWrite()
+
+  const [currencyDraft, setCurrencyDraft] = useState('')
+  const [currencyDirty, setCurrencyDirty] = useState(false)
+  const [businessNameDraft, setBusinessNameDraft] = useState('')
+  const [businessNameDirty, setBusinessNameDirty] = useState(false)
+
+  const settingsQuery = useQuery({
+    queryKey: ['org-payment-settings', session?.tenantId],
+    enabled: Boolean(session),
+    queryFn: async () => {
+      if (!session) throw new Error('Missing org session.')
+      const response = await getPaymentSettings(session)
+      return response.data
+    },
+  })
+
+  const currentSettings: PaymentSettings = settingsQuery.data ?? {}
+
+  const effectiveCurrency = currencyDirty
+    ? currencyDraft
+    : currentSettings.currency || ''
+
+  const effectiveBusinessName = businessNameDirty
+    ? businessNameDraft
+    : currentSettings.invoiceBusinessName || ''
+
+  const currencyMutation = useMutation<
+    PaymentSettings,
+    ApiClientError | Error,
+    { currency: string | null }
+  >({
+    mutationFn: async (payload) => {
+      if (!session) throw new Error('Missing org session.')
+      const response = await updatePaymentSettings(session, payload)
+      return response.data
+    },
+    onSuccess(result) {
+      setCurrencyDraft(result.currency || '')
+      setCurrencyDirty(false)
+      settingsQuery.refetch()
+    },
+  })
+
+  const businessNameMutation = useMutation<
+    PaymentSettings,
+    ApiClientError | Error,
+    { invoiceBusinessName: string | null }
+  >({
+    mutationFn: async (payload) => {
+      if (!session) throw new Error('Missing org session.')
+      const response = await updatePaymentSettings(session, payload)
+      return response.data
+    },
+    onSuccess(result) {
+      setBusinessNameDraft(result.invoiceBusinessName || '')
+      setBusinessNameDirty(false)
+      settingsQuery.refetch()
+    },
+  })
+
+  if (settingsQuery.isLoading) {
+    return (
+      <LoadingState
+        title="Loading payment settings"
+        message="Fetching the current payment configuration."
+      />
+    )
+  }
+
+  if (settingsQuery.isError) {
+    return (
+      <ErrorState
+        title="Could not load payment settings"
+        message="The payment settings page could not load the current configuration."
+        onRetry={() => void settingsQuery.refetch()}
+      />
+    )
+  }
+
+  return (
+    <div className="page-stack">
+      <PageHero
+        badge="Settings"
+        title="Payment settings"
+        description="Configure currency and invoicing details used for paid course enrollments."
+      />
+
+      {!canWrite ? (
+        <section className="content-panel content-panel--narrow">
+          <div className="designer-banner designer-banner--warning" role="status">
+            <strong>You have read-only access to this tenant.</strong>
+            <span>Contact an Org Admin to make changes.</span>
+          </div>
+        </section>
+      ) : null}
+
+      <section className="content-panel">
+        <SectionHeader
+          eyebrow="Currency"
+          title="Payment currency"
+          description="Set the currency used for paid course enrollments. Leave blank to disable paid enrollments."
+        />
+        {canWrite ? (
+          <form
+            className="session-form"
+            onSubmit={(event) => {
+              event.preventDefault()
+              currencyMutation.mutate({
+                currency: effectiveCurrency.trim().toLowerCase() || null,
+              })
+            }}
+          >
+            <label className="session-form__field">
+              <span>Currency code</span>
+              <select
+                value={effectiveCurrency.toUpperCase()}
+                onChange={(e) => {
+                  setCurrencyDirty(true)
+                  setCurrencyDraft(e.target.value.toLowerCase())
+                }}
+              >
+                <option value="">Not set (free courses only)</option>
+                <option value="AUD">AUD — Australian Dollar</option>
+                <option value="USD">USD — US Dollar</option>
+                <option value="GBP">GBP — British Pound</option>
+                <option value="NZD">NZD — New Zealand Dollar</option>
+                <option value="CAD">CAD — Canadian Dollar</option>
+                <option value="EUR">EUR — Euro</option>
+                <option value="SGD">SGD — Singapore Dollar</option>
+              </select>
+            </label>
+            <div className="session-form__actions">
+              <button
+                className="button button--primary"
+                disabled={currencyMutation.isPending}
+                type="submit"
+              >
+                {currencyMutation.isPending ? 'Saving...' : 'Save currency'}
+              </button>
+              {currencyMutation.isError ? (
+                <p className="session-form__error">Failed to save currency setting.</p>
+              ) : null}
+            </div>
+          </form>
+        ) : (
+          <p>{effectiveCurrency.toUpperCase() || 'Not set'}</p>
+        )}
+      </section>
+
+      <section className="content-panel">
+        <SectionHeader
+          eyebrow="Invoicing"
+          title="Business name for invoicing"
+          description="This name appears on payment receipts and invoices sent to enrollees."
+        />
+        {canWrite ? (
+          <form
+            className="session-form"
+            onSubmit={(event) => {
+              event.preventDefault()
+              businessNameMutation.mutate({
+                invoiceBusinessName: effectiveBusinessName.trim() || null,
+              })
+            }}
+          >
+            <label className="session-form__field">
+              <span>Business name</span>
+              <input
+                type="text"
+                value={effectiveBusinessName}
+                onChange={(e) => {
+                  setBusinessNameDirty(true)
+                  setBusinessNameDraft(e.target.value)
+                }}
+                placeholder="e.g. Acme Training Pty Ltd"
+              />
+            </label>
+            <div className="session-form__actions">
+              <button
+                className="button button--primary"
+                disabled={businessNameMutation.isPending}
+                type="submit"
+              >
+                {businessNameMutation.isPending ? 'Saving...' : 'Save business name'}
+              </button>
+              {businessNameMutation.isError ? (
+                <p className="session-form__error">Failed to save business name.</p>
+              ) : null}
+            </div>
+          </form>
+        ) : (
+          <p>{effectiveBusinessName || 'Not set'}</p>
+        )}
+      </section>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

Post-Stripe launch fixes identified during manual testing:

- **Pricing mode**: rename `paid_placeholder` → `paid` in `PricingMode` type and course editor dropdown; activate variant price field (was disabled/reserved)
- **Variant dates**: remove `startDate`/`endDate` from `VariantEditorCard` form fields, `VariantFormState`, `toPayload`, and `VariantSelector` meta row — dates live on the course, not the variant
- **Payment settings page**: new `/org/payment-settings` route with currency selector and business name for invoicing field; added to sidebar nav
- **Branding page**: remove the currency section (moved to Payment Settings)
- **API client**: add `getPaymentSettings` / `updatePaymentSettings` functions; add `PaymentSettings` and `PaymentSettingsUpdatePayload` types; remove `currency` from branding types

## Test plan

- [x] `npm run lint` — no errors
- [x] `npm test` — 54 tests, 0 failures
- [ ] Open course editor — pricing mode shows "Free" / "Paid" (no "Placeholder")
- [ ] Open variant editor — no start/end date fields; price field is editable
- [ ] Navigate to Payment Settings — currency and business name forms work end-to-end
- [ ] Confirm Branding page no longer shows currency section

🤖 Generated with [Claude Code](https://claude.com/claude-code)