### PR TITLE
feat: per-tenant theming

### DIFF
--- a/src/components/layout/OrgLayout.tsx
+++ b/src/components/layout/OrgLayout.tsx
@@ -1,28 +1,44 @@
+import { useQuery } from '@tanstack/react-query'
 import { useState } from 'react'
 import { Outlet } from 'react-router-dom'
+import { TenantThemeProvider } from '../../features/theming/TenantThemeProvider'
+import { useOrgSession } from '../../features/org-session/useOrgSession'
+import { getBranding } from '../../lib/api'
 import { OrgSidebar } from './OrgSidebar'
 import { SiteHeader } from './SiteHeader'
 
 export function OrgLayout() {
   const [sidebarOpen, setSidebarOpen] = useState(false)
+  const { session } = useOrgSession()
+
+  const brandingQuery = useQuery({
+    queryKey: ['org-branding', session?.tenantId],
+    enabled: Boolean(session?.tenantId),
+    queryFn: async () => {
+      const response = await getBranding(session!)
+      return response.data
+    },
+  })
 
   return (
-    <div className="portal-shell">
-      <div
-        className={sidebarOpen ? 'portal-sidebar-overlay portal-sidebar-overlay--visible' : 'portal-sidebar-overlay'}
-        onClick={() => setSidebarOpen(false)}
-        aria-hidden="true"
-      />
-      <OrgSidebar isOpen={sidebarOpen} onClose={() => setSidebarOpen(false)} />
-      <div className="portal-shell__content">
-        <SiteHeader
-          section="org"
-          onMenuToggle={() => setSidebarOpen((o) => !o)}
+    <TenantThemeProvider theme={brandingQuery.data?.theme}>
+      <div className="portal-shell">
+        <div
+          className={sidebarOpen ? 'portal-sidebar-overlay portal-sidebar-overlay--visible' : 'portal-sidebar-overlay'}
+          onClick={() => setSidebarOpen(false)}
+          aria-hidden="true"
         />
-        <main className="portal-shell__body">
-          <Outlet />
-        </main>
+        <OrgSidebar isOpen={sidebarOpen} onClose={() => setSidebarOpen(false)} />
+        <div className="portal-shell__content">
+          <SiteHeader
+            section="org"
+            onMenuToggle={() => setSidebarOpen((o) => !o)}
+          />
+          <main className="portal-shell__body">
+            <Outlet />
+          </main>
+        </div>
       </div>
-    </div>
+    </TenantThemeProvider>
   )
 }

--- a/src/components/routing/TenantRouteGuard.tsx
+++ b/src/components/routing/TenantRouteGuard.tsx
@@ -1,13 +1,29 @@
+import { useQuery } from '@tanstack/react-query'
 import { Outlet, useParams } from 'react-router-dom'
-import { NotFoundPage } from '../../pages/NotFoundPage'
+import { TenantThemeProvider } from '../../features/theming/TenantThemeProvider'
+import { getPublicTenantHome } from '../../lib/api'
 import { isValidTenantCode } from '../../lib/routing/tenantCode'
+import { NotFoundPage } from '../../pages/NotFoundPage'
 
 export function TenantRouteGuard() {
   const { tenantCode } = useParams()
+
+  const tenantQuery = useQuery({
+    queryKey: ['tenant-home', tenantCode],
+    queryFn: async () => {
+      const response = await getPublicTenantHome(tenantCode!)
+      return response.data
+    },
+    enabled: Boolean(tenantCode) && isValidTenantCode(tenantCode ?? ''),
+  })
 
   if (!tenantCode || !isValidTenantCode(tenantCode)) {
     return <NotFoundPage />
   }
 
-  return <Outlet />
+  return (
+    <TenantThemeProvider theme={tenantQuery.data?.branding?.theme}>
+      <Outlet />
+    </TenantThemeProvider>
+  )
 }

--- a/src/features/theming/TenantThemeContext.ts
+++ b/src/features/theming/TenantThemeContext.ts
@@ -1,0 +1,8 @@
+import { createContext } from 'react'
+import type { TenantTheme } from '../../lib/api/types'
+
+export type TenantThemeContextValue = {
+  theme: TenantTheme | null
+}
+
+export const TenantThemeContext = createContext<TenantThemeContextValue>({ theme: null })

--- a/src/features/theming/TenantThemeProvider.tsx
+++ b/src/features/theming/TenantThemeProvider.tsx
@@ -1,0 +1,79 @@
+import { useEffect, useId, type PropsWithChildren } from 'react'
+import type { TenantTheme } from '../../lib/api/types'
+import { TenantThemeContext } from './TenantThemeContext'
+
+function hexToRgb(hex: string): string {
+  const r = parseInt(hex.slice(1, 3), 16)
+  const g = parseInt(hex.slice(3, 5), 16)
+  const b = parseInt(hex.slice(5, 7), 16)
+  return `${r}, ${g}, ${b}`
+}
+
+function buildThemeCSS(theme: TenantTheme): string {
+  const vars: string[] = []
+
+  if (theme.accentColor) {
+    vars.push(`  --color-accent: ${theme.accentColor};`)
+    const rgb = hexToRgb(theme.accentColor)
+    vars.push(`  --color-border: rgba(${rgb}, 0.12);`)
+    vars.push(`  --color-border-strong: rgba(${rgb}, 0.28);`)
+    vars.push(`  --color-bg-soft: rgba(${rgb}, 0.08);`)
+    vars.push(`  --color-bg-muted: rgba(${rgb}, 0.04);`)
+    vars.push(`  --shadow-surface: 0 4px 20px rgba(${rgb}, 0.09);`)
+    vars.push(`  --shadow-drawer: 0 8px 32px rgba(${rgb}, 0.15);`)
+  }
+
+  if (theme.accentStrongColor) {
+    vars.push(`  --color-accent-strong: ${theme.accentStrongColor};`)
+  }
+
+  if (theme.ctaColor) {
+    vars.push(`  --color-cta: ${theme.ctaColor};`)
+  }
+
+  if (theme.bgColor) {
+    vars.push(`  --color-bg: ${theme.bgColor};`)
+  }
+
+  if (theme.textColor) {
+    vars.push(`  --color-text: ${theme.textColor};`)
+  }
+
+  if (theme.fontFamily) {
+    vars.push(`  --font-ui: ${theme.fontFamily};`)
+  }
+
+  if (vars.length === 0) return ''
+  return `:root {\n${vars.join('\n')}\n}`
+}
+
+type TenantThemeProviderProps = PropsWithChildren<{
+  theme?: TenantTheme | null
+}>
+
+export function TenantThemeProvider({ theme, children }: TenantThemeProviderProps) {
+  const rawId = useId()
+  const styleId = `tenant-theme-${rawId.replace(/:/g, '')}`
+
+  useEffect(() => {
+    if (!theme) return
+
+    const css = buildThemeCSS(theme)
+    if (!css) return
+
+    const styleEl = document.createElement('style')
+    styleEl.id = styleId
+    styleEl.textContent = css
+    document.head.appendChild(styleEl)
+
+    return () => {
+      document.getElementById(styleId)?.remove()
+    }
+  }, [theme, styleId])
+
+  return (
+    <TenantThemeContext.Provider value={{ theme: theme ?? null }}>
+      {children}
+    </TenantThemeContext.Provider>
+  )
+}

--- a/src/features/theming/TenantThemeProvider.tsx
+++ b/src/features/theming/TenantThemeProvider.tsx
@@ -9,6 +9,13 @@ function hexToRgb(hex: string): string {
   return `${r}, ${g}, ${b}`
 }
 
+function darkenHex(hex: string, factor = 0.85): string {
+  const r = Math.round(parseInt(hex.slice(1, 3), 16) * factor)
+  const g = Math.round(parseInt(hex.slice(3, 5), 16) * factor)
+  const b = Math.round(parseInt(hex.slice(5, 7), 16) * factor)
+  return `#${r.toString(16).padStart(2, '0')}${g.toString(16).padStart(2, '0')}${b.toString(16).padStart(2, '0')}`
+}
+
 function buildThemeCSS(theme: TenantTheme): string {
   const vars: string[] = []
 
@@ -29,6 +36,7 @@ function buildThemeCSS(theme: TenantTheme): string {
 
   if (theme.ctaColor) {
     vars.push(`  --color-cta: ${theme.ctaColor};`)
+    vars.push(`  --color-cta-strong: ${darkenHex(theme.ctaColor)};`)
   }
 
   if (theme.bgColor) {

--- a/src/features/theming/useTenantTheme.ts
+++ b/src/features/theming/useTenantTheme.ts
@@ -1,5 +1,5 @@
 import { useContext } from 'react'
-import { TenantThemeContext } from './TenantThemeProvider'
+import { TenantThemeContext } from './TenantThemeContext'
 
 export function useTenantTheme() {
   return useContext(TenantThemeContext)

--- a/src/features/theming/useTenantTheme.ts
+++ b/src/features/theming/useTenantTheme.ts
@@ -1,0 +1,6 @@
+import { useContext } from 'react'
+import { TenantThemeContext } from './TenantThemeProvider'
+
+export function useTenantTheme() {
+  return useContext(TenantThemeContext)
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1575,6 +1575,26 @@ textarea:focus-visible {
   word-break: break-all;
 }
 
+.theme-color-row {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.theme-color-row input[type='color'] {
+  width: 2.5rem;
+  height: 2.5rem;
+  padding: 0.15rem;
+  border-radius: var(--radius-control);
+  border: 1px solid var(--color-border);
+  cursor: pointer;
+  flex-shrink: 0;
+}
+
+.theme-color-row input[type='text'] {
+  flex: 1;
+}
+
 .designer-field-list {
   display: grid;
   gap: 1rem;

--- a/src/index.css
+++ b/src/index.css
@@ -19,6 +19,7 @@
   --color-accent: #6c47ff;
   --color-accent-strong: #5235cc;
   --color-cta: #ff6b35;
+  --color-cta-strong: #e05a27;
   --color-success-bg: rgba(22, 163, 74, 0.12);
   --color-success-text: #15803d;
   --color-warning-bg: rgba(234, 179, 8, 0.15);
@@ -619,15 +620,15 @@ textarea:focus-visible {
 
 .button--primary,
 .search-panel button {
-  background: var(--color-accent);
+  background: var(--color-cta);
   color: #fff;
-  box-shadow: 0 4px 14px rgba(108, 71, 255, 0.35);
+  box-shadow: 0 4px 14px rgba(255, 107, 53, 0.35);
 }
 
 .button--primary:hover,
 .search-panel button:hover {
-  background: var(--color-accent-strong);
-  box-shadow: 0 6px 20px rgba(108, 71, 255, 0.45);
+  background: var(--color-cta-strong);
+  box-shadow: 0 6px 20px rgba(255, 107, 53, 0.45);
 }
 
 .button--primary:active,

--- a/src/lib/api/types.ts
+++ b/src/lib/api/types.ts
@@ -355,10 +355,20 @@ export type OrgAsset = {
   url?: string
 }
 
+export type TenantTheme = {
+  accentColor?: string | null
+  accentStrongColor?: string | null
+  ctaColor?: string | null
+  bgColor?: string | null
+  textColor?: string | null
+  fontFamily?: string | null
+}
+
 export type BrandingUpdatePayload = {
   logoAssetId?: string | null
   description?: string | null
   homePageContent?: string | null
+  theme?: TenantTheme
 }
 
 export type BrandingSettings = {
@@ -368,6 +378,7 @@ export type BrandingSettings = {
   homePageContent?: string | null
   logoAssetId: string | null
   logoUrl?: string | null
+  theme?: TenantTheme | null
   updatedAt?: string
 }
 
@@ -408,6 +419,7 @@ export type TenantHome = {
   branding?: {
     logoAssetId?: string | null
     logoUrl?: string | null
+    theme?: TenantTheme | null
   }
   links: {
     home?: string

--- a/src/pages/org/BrandingPage.tsx
+++ b/src/pages/org/BrandingPage.tsx
@@ -17,6 +17,7 @@ import {
   type BrandingSettings,
   type BrandingUpdateResponse,
   type OrgAsset,
+  type TenantTheme,
   type UploadTicketResponse,
 } from '../../lib/api'
 
@@ -53,6 +54,8 @@ export function BrandingPage() {
   const [uploadedAsset, setUploadedAsset] = useState<OrgAsset | null>(null)
   const [descriptionDraft, setDescriptionDraft] = useState('')
   const [descriptionDirty, setDescriptionDirty] = useState(false)
+  const [themeDraft, setThemeDraft] = useState<TenantTheme>({})
+  const [themeDirty, setThemeDirty] = useState(false)
   const [brandingResult, setBrandingResult] =
     useState<BrandingUpdateResponse | null>(null)
 
@@ -76,6 +79,8 @@ export function BrandingPage() {
   const effectiveDescriptionDraft = descriptionDirty
     ? descriptionDraft
     : currentBranding?.description || ''
+
+  const effectiveTheme = themeDirty ? themeDraft : (currentBranding?.theme ?? {})
 
   const uploadMutation = useMutation<
     OrgAsset,
@@ -107,7 +112,7 @@ export function BrandingPage() {
   const brandingMutation = useMutation<
     BrandingUpdateResponse,
     ApiClientError | Error,
-    { logoAssetId?: string | null; description?: string | null }
+    { logoAssetId?: string | null; description?: string | null; theme?: TenantTheme }
   >({
     mutationFn: async (payload) => {
       if (!session) {
@@ -121,6 +126,7 @@ export function BrandingPage() {
       setBrandingResult(result)
       setDescriptionDraft(result.description || '')
       setDescriptionDirty(false)
+      setThemeDirty(false)
       brandingQuery.refetch()
     },
   })
@@ -239,6 +245,107 @@ export function BrandingPage() {
                   Failed to save tenant description.
                 </p>
               ) : null}
+            </div>
+          </form>
+        </section>
+      ) : null}
+
+      {canWrite ? (
+        <section className="content-panel">
+          <SectionHeader
+            eyebrow="Visual theme"
+            title="Tenant color scheme and typography"
+            description="Override the default platform colors and font for this tenant's public and org portal pages. Leave fields blank to use the platform default."
+          />
+          <form
+            className="session-form"
+            onSubmit={(event) => {
+              event.preventDefault()
+              brandingMutation.mutate({ theme: themeDraft })
+            }}
+          >
+            <div className="detail-summary-grid">
+              {(
+                [
+                  ['accentColor', 'Accent / primary color', '#6c47ff'],
+                  ['accentStrongColor', 'Accent strong (hover / active)', '#5235cc'],
+                  ['ctaColor', 'Call-to-action button color', '#ff6b35'],
+                  ['bgColor', 'Page background color', '#f8f7ff'],
+                  ['textColor', 'Body text color', '#1a1a2e'],
+                ] as const
+              ).map(([field, label, platformDefault]) => (
+                <label key={field} className="session-form__field">
+                  <span>{label}</span>
+                  <div className="theme-color-row">
+                    <input
+                      type="color"
+                      value={effectiveTheme[field] ?? platformDefault}
+                      onChange={(e) => {
+                        setThemeDirty(true)
+                        setThemeDraft((prev) => ({ ...prev, [field]: e.target.value }))
+                      }}
+                    />
+                    <input
+                      type="text"
+                      placeholder="e.g. #6c47ff — blank to use default"
+                      value={effectiveTheme[field] ?? ''}
+                      onChange={(e) => {
+                        setThemeDirty(true)
+                        setThemeDraft((prev) => ({
+                          ...prev,
+                          [field]: e.target.value.trim() || null,
+                        }))
+                      }}
+                    />
+                  </div>
+                </label>
+              ))}
+              <label className="session-form__field">
+                <span>Font family</span>
+                <input
+                  type="text"
+                  placeholder="e.g. Georgia, serif — blank to use default"
+                  value={effectiveTheme.fontFamily ?? ''}
+                  maxLength={100}
+                  onChange={(e) => {
+                    setThemeDirty(true)
+                    setThemeDraft((prev) => ({
+                      ...prev,
+                      fontFamily: e.target.value.trim() || null,
+                    }))
+                  }}
+                />
+                <p className="content-panel__body-copy">
+                  Use a CSS font-family stack with system fonts or generic families (e.g. <code>Georgia, serif</code>). Custom web fonts must already be available in the browser.
+                </p>
+              </label>
+            </div>
+            <div className="session-form__actions">
+              <button
+                className="button button--primary"
+                disabled={brandingMutation.isPending || !themeDirty}
+                type="submit"
+              >
+                {brandingMutation.isPending ? 'Saving theme...' : 'Save theme'}
+              </button>
+              <button
+                className="button button--ghost"
+                type="button"
+                disabled={brandingMutation.isPending}
+                onClick={() => {
+                  setThemeDirty(true)
+                  setThemeDraft({
+                    accentColor: null,
+                    accentStrongColor: null,
+                    ctaColor: null,
+                    bgColor: null,
+                    textColor: null,
+                    fontFamily: null,
+                  })
+                }}
+              >
+                Reset to platform defaults
+              </button>
             </div>
           </form>
         </section>


### PR DESCRIPTION
## Summary

- `TenantThemeContext.ts` — React context in its own file (required by `react-refresh/only-export-components`)
- `TenantThemeProvider.tsx` — injects a `<style>` tag into `<head>` with `:root` CSS variable overrides; derives `--color-cta-strong` (15% darken) and rgba border/shadow variables from `accentColor`
- `useTenantTheme.ts` — hook in its own file
- `TenantRouteGuard.tsx` — wraps `<Outlet>` in `TenantThemeProvider` using the same React Query cache key as `TenantHomePage` (no extra request)
- `OrgLayout.tsx` — wraps the org portal shell in `TenantThemeProvider` using the same cache key as `BrandingPage`
- `BrandingPage.tsx` — adds a color + font editor section with platform-default color pickers, dedicated theme form submit, and a reset-to-defaults button
- `index.css` — primary buttons now consume `--color-cta` / `--color-cta-strong` (default `#ff6b35` / `#e05a27`); `--color-cta-strong` added to `:root`; `.theme-color-row` styles added
- `types.ts` — `TenantTheme` type; `BrandingSettings`, `TenantHome.branding`, `BrandingUpdatePayload` extended

## Test plan

- [ ] Frontend lint passes on all changed files
- [ ] TypeScript compiles cleanly on changed files
- [ ] Navigate to `/:tenantCode` — accent color matches the tenant's saved `accentColor`
- [ ] Navigate to `/org/branding` — theme editor renders with correct default color picker values; saving persists and applies immediately
- [ ] "Reset to platform defaults" sets all fields to null and restores default appearance
- [ ] A tenant with no theme configured renders identically to the pre-feature app

🤖 Generated with [Claude Code](https://claude.com/claude-code)