### PR TITLE
fix: wrap sibling forms in fragment in InternalTenantsPage

### DIFF
--- a/src/pages/internal/InternalTenantsPage.tsx
+++ b/src/pages/internal/InternalTenantsPage.tsx
@@ -499,6 +499,7 @@ export function InternalTenantsPage() {
                       />
                     ) : null}
                     {editFormState ? (
+                      <>
                       <form
                         className="session-form"
                         onSubmit={(event) => {
@@ -649,6 +650,7 @@ export function InternalTenantsPage() {
                           ) : null}
                         </div>
                       </form>
+                      </>
                     ) : null}
                   </>
                 ) : (


### PR DESCRIPTION
## Summary

- The `editFormState` conditional rendered two sibling `<form>` elements without a common parent, causing `Parsing error: JSX expressions must have one parent element` in CI lint
- Fix: wrap both forms in a `<>...</>` fragment

## Test plan

- [ ] `npx eslint src/pages/internal/InternalTenantsPage.tsx` passes with no errors
- [ ] CI lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)