### PR TITLE
feat: UI improvements across public and org portals

### DIFF
--- a/src/components/layout/OrgWorkspaceNav.tsx
+++ b/src/components/layout/OrgWorkspaceNav.tsx
@@ -36,16 +36,18 @@ export function OrgWorkspaceNav({
           const body = (
             <>
               <div className="org-workspace-nav__item-top">
-                {item.icon ? (
-                  <span className="org-workspace-nav__item-icon" aria-hidden="true">
-                    {item.icon}
-                  </span>
-                ) : null}
+                <div className="org-workspace-nav__item-title">
+                  {item.icon ? (
+                    <span className="org-workspace-nav__item-icon" aria-hidden="true">
+                      {item.icon}
+                    </span>
+                  ) : null}
+                  <strong>{item.label}</strong>
+                </div>
                 {isCurrent ? (
                   <span className="org-workspace-nav__active-badge">Active</span>
                 ) : null}
               </div>
-              <strong>{item.label}</strong>
               <p>{item.description}</p>
             </>
           )

--- a/src/index.css
+++ b/src/index.css
@@ -126,7 +126,7 @@ textarea:focus-visible {
 }
 
 .app-frame__body {
-  width: min(1120px, calc(100% - 2rem));
+  width: min(1440px, calc(100% - 2rem));
   margin: 0 auto;
   padding: 2rem 0 4rem;
 }
@@ -146,7 +146,7 @@ textarea:focus-visible {
 }
 
 .site-header__inner {
-  width: min(1120px, calc(100% - 2rem));
+  width: min(1440px, calc(100% - 2rem));
   margin: 0 auto;
   display: flex;
   align-items: center;
@@ -274,6 +274,7 @@ textarea:focus-visible {
 /* === HERO & CARDS === */
 .page-stack {
   display: grid;
+  grid-template-columns: minmax(0, 1fr);
   gap: var(--space-3);
 }
 
@@ -319,6 +320,14 @@ textarea:focus-visible {
   font-size: clamp(1.6rem, 3vw, 2.25rem);
   line-height: 1.15;
   letter-spacing: -0.025em;
+}
+
+.page-hero--public .page-hero__content {
+  max-width: none;
+}
+
+.page-hero--public .page-hero__content > p {
+  max-width: none;
 }
 
 .page-hero--public h1 {
@@ -556,6 +565,16 @@ textarea:focus-visible {
   letter-spacing: -0.03em;
 }
 
+.course-card h2 a {
+  color: var(--color-accent);
+  text-decoration: none;
+}
+
+.course-card h2 a:hover {
+  color: var(--color-accent-strong);
+  text-decoration: underline;
+}
+
 .destination-card p,
 .state-card p,
 .course-card p,
@@ -694,6 +713,7 @@ textarea:focus-visible {
   display: grid;
   gap: 1rem;
   grid-template-columns: minmax(0, 2fr) minmax(180px, 1fr) auto;
+  align-items: end;
   padding: 1rem;
 }
 
@@ -1100,6 +1120,34 @@ textarea:focus-visible {
   margin-top: 0.4rem;
 }
 
+.branding-tenant-row {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.detail-summary-grid--three-col {
+  grid-template-columns: repeat(3, 1fr);
+}
+
+.branding-tenant-row--wide {
+  grid-column: span 2;
+}
+
+.branding-tenant-info {
+  flex: 1;
+}
+
+
+.branding-logo-asset-id {
+  display: flex;
+  align-items: baseline;
+  gap: 0.6rem;
+  margin-top: 0.6rem;
+  font-size: 0.88rem;
+  color: var(--color-text-muted);
+}
+
 /* === STATUS === */
 .status-pill {
   display: inline-flex;
@@ -1328,8 +1376,7 @@ textarea:focus-visible {
   box-shadow: var(--shadow-drawer);
 }
 
-.content-panel--narrow,
-.state-card {
+.content-panel--narrow {
   max-width: 48rem;
 }
 
@@ -1509,6 +1556,29 @@ textarea:focus-visible {
   font-size: 0.85rem;
   text-transform: uppercase;
   letter-spacing: 0.05em;
+}
+
+.invite-form__row {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1rem;
+}
+
+.data-table__role-cell {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.data-table__role-cell select {
+  flex: 1;
+  border: 1px solid rgba(19, 34, 56, 0.14);
+  border-radius: var(--radius-control);
+  background: #fff;
+  padding: 0.3rem 0.6rem;
+  font: inherit;
+  font-size: 0.88rem;
+  color: inherit;
 }
 
 .table-subtext {
@@ -1826,7 +1896,7 @@ textarea:focus-visible {
 
 .portal-shell__body {
   flex: 1;
-  width: min(1000px, calc(100% - 2rem));
+  width: min(1280px, calc(100% - 2rem));
   margin: 0 auto;
   padding: 2rem 0 4rem;
 }
@@ -1915,9 +1985,16 @@ textarea:focus-visible {
 
 .org-course-card__title {
   font-size: 1rem;
+  font-weight: 700;
   letter-spacing: -0.02em;
-  color: var(--color-text);
+  color: var(--color-accent);
   line-height: 1.35;
+  text-decoration: none;
+}
+
+.org-course-card__title:hover {
+  color: var(--color-accent-strong);
+  text-decoration: underline;
 }
 
 .org-course-card__summary {
@@ -1952,6 +2029,16 @@ textarea:focus-visible {
   font-size: 0.8rem;
   text-transform: uppercase;
   letter-spacing: 0.04em;
+}
+
+.org-course-card__meta-edit {
+  margin-left: auto;
+  color: var(--color-accent);
+  text-decoration: none;
+}
+
+.org-course-card__meta-edit:hover {
+  text-decoration: underline;
 }
 
 .org-course-card__actions {
@@ -2691,7 +2778,7 @@ textarea:focus-visible {
 }
 
 .public-site-footer__inner {
-  width: min(1120px, calc(100% - 2rem));
+  width: min(1440px, calc(100% - 2rem));
   margin: 0 auto;
   padding: var(--space-4) 0 var(--space-3);
 }
@@ -2748,13 +2835,32 @@ textarea:focus-visible {
   box-shadow: 0 8px 32px rgba(108, 71, 255, 0.30);
 }
 
+.page-hero--org .page-hero__content {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  column-gap: 1.25rem;
+  align-items: center;
+  max-width: none;
+}
+
+.page-hero--org .page-hero__badge {
+  grid-column: 1;
+  grid-row: 1;
+}
+
 .page-hero--org h1 {
+  grid-column: 2;
+  grid-row: 1;
   color: #fff;
   font-size: clamp(1.8rem, 3.5vw, 2.6rem);
+  margin: 0;
 }
 
 .page-hero--org .page-hero__content > p {
+  grid-column: 1 / -1;
+  grid-row: 2;
   color: rgba(255, 255, 255, 0.78);
+  max-width: none;
 }
 
 /* Circular workspace badge for org hero */
@@ -2812,6 +2918,12 @@ textarea:focus-visible {
   justify-content: space-between;
   gap: 0.5rem;
   margin-bottom: 0.5rem;
+}
+
+.org-workspace-nav__item-title {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
 }
 
 .org-workspace-nav__item-icon {

--- a/src/pages/org/BrandingPage.tsx
+++ b/src/pages/org/BrandingPage.tsx
@@ -21,6 +21,48 @@ import {
   type UploadTicketResponse,
 } from '../../lib/api'
 
+const FONT_OPTIONS = [
+  { label: 'Platform default', value: '' },
+  { label: 'System UI', value: "-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif" },
+  { label: 'Georgia', value: "Georgia, 'Times New Roman', serif" },
+  { label: 'Arial', value: 'Arial, Helvetica, sans-serif' },
+  { label: 'Verdana', value: 'Verdana, Geneva, sans-serif' },
+  { label: 'Trebuchet MS', value: "'Trebuchet MS', Helvetica, sans-serif" },
+  { label: 'Tahoma', value: 'Tahoma, Geneva, sans-serif' },
+  { label: 'Palatino', value: "'Palatino Linotype', Palatino, serif" },
+  { label: 'Courier New', value: "'Courier New', Courier, monospace" },
+]
+
+const CUSTOM_FONT_SENTINEL = '__custom__'
+
+const COLOR_SCHEMES = [
+  {
+    label: 'Platform Default',
+    value: 'default',
+    colors: { accentColor: '#6c47ff', accentStrongColor: '#5235cc', ctaColor: '#ff6b35', bgColor: '#f8f7ff', textColor: '#1a1a2e' },
+  },
+  {
+    label: 'Ocean',
+    value: 'ocean',
+    colors: { accentColor: '#0ea5e9', accentStrongColor: '#0369a1', ctaColor: '#f59e0b', bgColor: '#f0f9ff', textColor: '#0f172a' },
+  },
+  {
+    label: 'Forest',
+    value: 'forest',
+    colors: { accentColor: '#16a34a', accentStrongColor: '#15803d', ctaColor: '#f97316', bgColor: '#f0fdf4', textColor: '#1a2e1a' },
+  },
+  {
+    label: 'Crimson',
+    value: 'crimson',
+    colors: { accentColor: '#dc2626', accentStrongColor: '#b91c1c', ctaColor: '#2563eb', bgColor: '#fff5f5', textColor: '#1c1414' },
+  },
+  {
+    label: 'Slate',
+    value: 'slate',
+    colors: { accentColor: '#475569', accentStrongColor: '#334155', ctaColor: '#0ea5e9', bgColor: '#f8fafc', textColor: '#0f172a' },
+  },
+]
+
 async function uploadAssetBinary(ticket: UploadTicketResponse, file: File) {
   let response: Response
 
@@ -164,20 +206,29 @@ export function BrandingPage() {
           title="Tenant identity currently in use"
           description="Logo and description changes here flow through to the public tenant page."
         />
-        <div className="detail-summary-grid">
-          <div className="field-card">
-            <span>Tenant</span>
-            <strong>{currentBranding?.displayName || session?.tenantId || 'Unknown'}</strong>
-          </div>
-          <div className="field-card">
-            <span>Logo asset ID</span>
-            <strong>{currentBranding?.logoAssetId || 'None'}</strong>
+        <div className="detail-summary-grid detail-summary-grid--three-col">
+          <div className="branding-tenant-row branding-tenant-row--wide">
+            {currentBranding?.logoUrl ? (
+              <img
+                alt={`${currentBranding.displayName || 'Tenant'} logo`}
+                className="tenant-logo tenant-logo--inline"
+                src={currentBranding.logoUrl}
+              />
+            ) : null}
+            <div className="field-card branding-tenant-info">
+              <span>Tenant</span>
+              <strong>{currentBranding?.displayName || session?.tenantId || 'Unknown'}</strong>
+            </div>
           </div>
           <div className="field-card">
             <span>Description status</span>
             <strong>{effectiveDescriptionDraft.trim() ? 'Configured' : 'Missing'}</strong>
           </div>
         </div>
+        <p className="branding-logo-asset-id">
+          <span>Logo asset ID</span>
+          <strong>{currentBranding?.logoAssetId || 'None'}</strong>
+        </p>
         <div className="button-row">
           <StatusChip tone={currentBranding?.logoAssetId ? 'info' : 'warning'}>
             {currentBranding?.logoAssetId ? 'logo ready' : 'logo missing'}
@@ -186,16 +237,6 @@ export function BrandingPage() {
             {effectiveDescriptionDraft.trim() ? 'description ready' : 'description needed'}
           </StatusChip>
         </div>
-        {currentBranding?.logoUrl ? (
-          <div className="branding-preview">
-            <span>Current public logo</span>
-            <img
-              alt={`${currentBranding.displayName || 'Tenant'} current logo`}
-              className="tenant-logo"
-              src={currentBranding.logoUrl}
-            />
-          </div>
-        ) : null}
       </section>
 
       {!canWrite ? (
@@ -261,9 +302,35 @@ export function BrandingPage() {
             className="session-form"
             onSubmit={(event) => {
               event.preventDefault()
-              brandingMutation.mutate({ theme: themeDraft })
+              const themeToSave = { ...themeDraft }
+              const pendingFont = themeToSave.fontFamily
+              const fontIsCustomOrUntouched =
+                pendingFont === undefined ||
+                (pendingFont != null && pendingFont !== '' && !FONT_OPTIONS.some(o => o.value === pendingFont))
+              if (fontIsCustomOrUntouched) {
+                themeToSave.fontFamily = currentBranding?.theme?.fontFamily ?? null
+              }
+              brandingMutation.mutate({ theme: themeToSave })
             }}
           >
+            <label className="session-form__field">
+              <span>Colour scheme</span>
+              <select
+                value=""
+                onChange={(e) => {
+                  const scheme = COLOR_SCHEMES.find(s => s.value === e.target.value)
+                  if (!scheme) return
+                  setThemeDirty(true)
+                  setThemeDraft((prev) => ({ ...prev, ...scheme.colors }))
+                }}
+              >
+                <option value="">Apply a preset…</option>
+                {COLOR_SCHEMES.map(s => (
+                  <option key={s.value} value={s.value}>{s.label}</option>
+                ))}
+              </select>
+            </label>
+
             <div className="detail-summary-grid">
               {(
                 [
@@ -302,22 +369,30 @@ export function BrandingPage() {
               ))}
               <label className="session-form__field">
                 <span>Font family</span>
-                <input
-                  type="text"
-                  placeholder="e.g. Georgia, serif — blank to use default"
-                  value={effectiveTheme.fontFamily ?? ''}
-                  maxLength={100}
-                  onChange={(e) => {
-                    setThemeDirty(true)
-                    setThemeDraft((prev) => ({
-                      ...prev,
-                      fontFamily: e.target.value.trim() || null,
-                    }))
-                  }}
-                />
-                <p className="content-panel__body-copy">
-                  Use a CSS font-family stack with system fonts or generic families (e.g. <code>Georgia, serif</code>). Custom web fonts must already be available in the browser.
-                </p>
+                {(() => {
+                  const currentFont = effectiveTheme.fontFamily ?? ''
+                  const isCustom = currentFont !== '' && !FONT_OPTIONS.some(o => o.value === currentFont)
+                  return (
+                    <select
+                      value={isCustom ? CUSTOM_FONT_SENTINEL : currentFont}
+                      onChange={(e) => {
+                        if (e.target.value === CUSTOM_FONT_SENTINEL) return
+                        setThemeDirty(true)
+                        setThemeDraft((prev) => ({
+                          ...prev,
+                          fontFamily: e.target.value || null,
+                        }))
+                      }}
+                    >
+                      {FONT_OPTIONS.map(o => (
+                        <option key={o.value} value={o.value}>{o.label}</option>
+                      ))}
+                      {isCustom && (
+                        <option value={CUSTOM_FONT_SENTINEL}>Custom value</option>
+                      )}
+                    </select>
+                  )
+                })()}
               </label>
             </div>
             <div className="session-form__actions">

--- a/src/pages/org/CoursesPage.tsx
+++ b/src/pages/org/CoursesPage.tsx
@@ -139,7 +139,7 @@ export function CoursesPage() {
                     <div key={course.id} className="org-course-card">
                       <div className="org-course-card__header">
                         <div className="org-course-card__title-row">
-                          <strong className="org-course-card__title">{course.title}</strong>
+                          <Link className="org-course-card__title" to={`/org/courses/${course.id}`}>{course.title}</Link>
                           <StatusChip tone={courseStatusTone(course.status)}>
                             {course.status}
                           </StatusChip>
@@ -163,22 +163,10 @@ export function CoursesPage() {
                           {course.activeFormVersion
                             ? `Version ${course.activeFormVersion}`
                             : 'No form yet'}
+                          <Link className="org-course-card__meta-edit" to={`/org/courses/${course.id}/form`}>
+                            Edit
+                          </Link>
                         </span>
-                      </div>
-
-                      <div className="org-course-card__actions">
-                        <Link
-                          className="button button--outline"
-                          to={`/org/courses/${course.id}`}
-                        >
-                          Open details
-                        </Link>
-                        <Link
-                          className="button button--ghost-teal"
-                          to={`/org/courses/${course.id}/form`}
-                        >
-                          Form designer
-                        </Link>
                       </div>
                     </div>
                   ))}

--- a/src/pages/org/TeamPage.tsx
+++ b/src/pages/org/TeamPage.tsx
@@ -15,6 +15,7 @@ import {
   listOrgMembers,
   removeOrgMember,
   revokeOrgInvite,
+  updateOrgMemberRole,
   type OrgInvite,
   type OrgMember,
   type OrgRole,
@@ -85,6 +86,7 @@ export function TeamPage() {
   const [pendingRemoveUserId, setPendingRemoveUserId] = useState<string | null>(null)
   const [pendingRevokeInviteId, setPendingRevokeInviteId] = useState<string | null>(null)
   const [copiedInviteId, setCopiedInviteId] = useState<string | null>(null)
+  const [pendingRoleChange, setPendingRoleChange] = useState<Record<string, OrgRole>>({})
 
   const membersQuery = useQuery({
     queryKey: ['org-members', session?.tenantId],
@@ -140,6 +142,18 @@ export function TeamPage() {
     },
     onSuccess: () => {
       setPendingRemoveUserId(null)
+      void queryClient.invalidateQueries({ queryKey: ['org-members', session?.tenantId] })
+    },
+  })
+
+  const changeRoleMutation = useMutation({
+    mutationFn: async ({ userId, role }: { userId: string; role: OrgRole }) => {
+      if (!session) throw new Error('Missing org session.')
+      await updateOrgMemberRole(session, userId, role)
+      return userId
+    },
+    onSuccess: (userId) => {
+      setPendingRoleChange((prev) => { const next = { ...prev }; delete next[userId]; return next })
       void queryClient.invalidateQueries({ queryKey: ['org-members', session?.tenantId] })
     },
   })
@@ -223,7 +237,6 @@ export function TeamPage() {
                 <thead>
                   <tr>
                     <th scope="col">Email</th>
-                    <th scope="col">User ID</th>
                     <th scope="col">Role</th>
                     <th scope="col">Status</th>
                     <th scope="col">Joined</th>
@@ -236,8 +249,39 @@ export function TeamPage() {
                     return (
                       <tr key={member.userId}>
                         <td>{member.email ?? '—'}</td>
-                        <td>{member.userId}</td>
-                        <td>{ROLE_LABELS[member.role]}</td>
+                        <td>
+                          {isAdmin ? (
+                            <span className="data-table__role-cell">
+                              <select
+                                value={pendingRoleChange[member.userId] ?? member.role}
+                                onChange={(e) => {
+                                  const next = e.target.value as OrgRole
+                                  setPendingRoleChange((prev) =>
+                                    next === member.role
+                                      ? { ...prev, [member.userId]: undefined as unknown as OrgRole }
+                                      : { ...prev, [member.userId]: next }
+                                  )
+                                }}
+                              >
+                                {ROLE_OPTIONS.map((o) => (
+                                  <option key={o.value} value={o.value}>{o.label}</option>
+                                ))}
+                              </select>
+                              {pendingRoleChange[member.userId] && pendingRoleChange[member.userId] !== member.role ? (
+                                <button
+                                  className="button button--primary button--small"
+                                  type="button"
+                                  disabled={changeRoleMutation.isPending}
+                                  onClick={() => changeRoleMutation.mutate({ userId: member.userId, role: pendingRoleChange[member.userId] })}
+                                >
+                                  {changeRoleMutation.isPending ? 'Saving…' : 'Save'}
+                                </button>
+                              ) : null}
+                            </span>
+                          ) : (
+                            ROLE_LABELS[member.role]
+                          )}
+                        </td>
                         <td>
                           <StatusChip tone={memberStatusTone(member.status)}>
                             {member.status}
@@ -293,42 +337,44 @@ export function TeamPage() {
 
       {/* Invite form */}
       {canWrite ? (
-        <section className="content-panel content-panel--narrow">
+        <section className="content-panel">
           <SectionHeader
             eyebrow="Invite"
             title="Invite a team member"
             description="Sent invites are valid for 7 days. The recipient must register or sign in to accept."
           />
           <form className="session-form" onSubmit={handleInviteSubmit}>
-            <label className="session-form__field">
-              <span>Email address</span>
-              <input
-                type="email"
-                value={inviteForm.email}
-                onChange={(event) => {
-                  setFormError(null)
-                  setInviteForm((current) => ({ ...current, email: event.target.value }))
-                }}
-                placeholder="member@example.com"
-                autoComplete="off"
-              />
-            </label>
-            <label className="session-form__field">
-              <span>Role</span>
-              <select
-                value={inviteForm.role}
-                onChange={(event) => {
-                  setFormError(null)
-                  setInviteForm((current) => ({ ...current, role: event.target.value as OrgRole }))
-                }}
-              >
-                {ROLE_OPTIONS.map((option) => (
-                  <option key={option.value} value={option.value}>
-                    {option.label}
-                  </option>
-                ))}
-              </select>
-            </label>
+            <div className="invite-form__row">
+              <label className="session-form__field">
+                <span>Email address</span>
+                <input
+                  type="email"
+                  value={inviteForm.email}
+                  onChange={(event) => {
+                    setFormError(null)
+                    setInviteForm((current) => ({ ...current, email: event.target.value }))
+                  }}
+                  placeholder="member@example.com"
+                  autoComplete="off"
+                />
+              </label>
+              <label className="session-form__field">
+                <span>Role</span>
+                <select
+                  value={inviteForm.role}
+                  onChange={(event) => {
+                    setFormError(null)
+                    setInviteForm((current) => ({ ...current, role: event.target.value as OrgRole }))
+                  }}
+                >
+                  {ROLE_OPTIONS.map((option) => (
+                    <option key={option.value} value={option.value}>
+                      {option.label}
+                    </option>
+                  ))}
+                </select>
+              </label>
+            </div>
             {ROLE_OPTIONS.find((o) => o.value === inviteForm.role) ? (
               <p className="content-panel__body-copy">
                 {ROLE_OPTIONS.find((o) => o.value === inviteForm.role)!.description}

--- a/src/pages/public/CourseCatalogPage.tsx
+++ b/src/pages/public/CourseCatalogPage.tsx
@@ -5,7 +5,7 @@ import { EmptyState } from '../../components/feedback/EmptyState'
 import { ErrorState } from '../../components/feedback/ErrorState'
 import { LoadingState } from '../../components/feedback/LoadingState'
 import { PageHero } from '../../components/layout/PageHero'
-import { listPublicCourses, type CourseListItem } from '../../lib/api'
+import { getPublicTenantHome, listPublicCourses, type CourseListItem } from '../../lib/api'
 import { normalizeTenantCode } from '../../lib/routing/tenantCode'
 
 const pageSize = 9
@@ -50,6 +50,15 @@ export function CourseCatalogPage() {
   const [statusInput, setStatusInput] = useState(initialStatusFilter)
   const cursor = searchParams.get('cursor') ?? undefined
   const statusFilter = initialStatusFilter
+
+  const tenantQuery = useQuery({
+    queryKey: ['tenant-home', tenantCode],
+    queryFn: async () => {
+      const response = await getPublicTenantHome(tenantCode)
+      return response.data
+    },
+    enabled: Boolean(tenantCode),
+  })
 
   const courseQuery = useQuery({
     queryKey: ['public-courses', tenantCode, initialQuery, cursor],
@@ -96,10 +105,10 @@ export function CourseCatalogPage() {
   return (
     <div className="page-stack">
       <PageHero
-        badge="Browse Training"
+        badge="Course Catalog"
         badgeOutlined
         variant="public"
-        title="Discover Your Next Skills Journey"
+        title={tenantQuery.data?.displayName ?? 'Course Catalog'}
         description="Explore our wide range of professional development courses. Find the perfect training to advance your career and start your enrolment today."
       />
 
@@ -171,7 +180,11 @@ export function CourseCatalogPage() {
             <section className="course-grid" aria-label="Available courses">
               {courses.map((course) => (
                 <article key={course.id} className="course-card">
-                  <h2>{course.title}</h2>
+                  <h2>
+                    <Link to={course.links?.detail || `/${tenantCode}/courses/${course.id}`}>
+                      {course.title}
+                    </Link>
+                  </h2>
                   <p>{course.summary || 'Course summary coming soon.'}</p>
                   <div className="course-card__meta">
                     {course.deliveryMode ? (
@@ -208,12 +221,6 @@ export function CourseCatalogPage() {
                     >
                       {normalizeStatusLabel(course.enrollmentStatus)}
                     </span>
-                    <Link
-                      className="button button--outline"
-                      to={course.links?.detail || `/${tenantCode}/courses/${course.id}`}
-                    >
-                      Review course
-                    </Link>
                   </div>
                 </article>
               ))}


### PR DESCRIPTION
## Summary

Closes #111

A broad set of UI improvements across the public portal and org portal, focused on layout consistency, usability, and visual polish on wider screens.

- **Global:** Increased content max-width to 1440px (public) / 1280px (portal) for 2K monitors; fixed `page-stack` grid column sizing so all sibling panels share the same width; removed `max-width` from `state-card`
- **Course Catalog:** Course title is now a link; "Review course" button removed; org name shown as hero `<h1>`; hero expanded to full width; filter button aligned with inputs
- **Org Courses:** Course title is now a link; "Open details" button removed; "Form designer" button replaced with inline "Edit" link on the Form row; `OrgWorkspaceNav` icon and label on same row; org hero badge and title on same row
- **Branding:** Logo displayed inline beside Tenant card; logo asset ID shown as plain text row; font family replaced with named dropdown; five predefined colour scheme presets added
- **Users:** Inline role change select wired to `updateOrgMemberRole` API; User ID column removed; invite form full width with email and role side by side
- **Submissions:** Panel width inconsistency resolved

## Test plan

- [ ] Public catalog: org name appears in hero; course titles are clickable links; filter button aligns with inputs
- [ ] Org courses: title links to detail page; "Edit" link on Form row opens form designer; workspace nav cards show icon + label on same row
- [ ] Branding: logo appears beside tenant name; font family dropdown works; colour scheme presets populate colour fields; custom font value preserved on save
- [ ] Users: admin can change a member's role inline; non-admin sees plain text role; invite form is full width with side-by-side fields
- [ ] Submissions: filter panel and results panel are the same width
- [ ] All pages render correctly at 1080p and 2K widths

🤖 Generated with [Claude Code](https://claude.com/claude-code)