### PR TITLE
fix: update tests to match UI improvement changes

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -255,7 +255,7 @@ describe('App routing', () => {
         await screen.findByRole('heading', { name: /branding and public identity/i }),
       ).toBeInTheDocument()
       expect(
-        await screen.findByRole('img', { name: /standard school current logo/i }),
+        await screen.findByRole('img', { name: /standard school logo/i }),
       ).toHaveAttribute('src', 'https://assets.example.com/ast_logo_1.svg')
       expect(
         await screen.findByRole('textbox', { name: /tenant description/i }),
@@ -286,7 +286,7 @@ describe('App routing', () => {
     renderRoute('/t/acme-training/courses')
 
     expect(
-      await screen.findByRole('heading', { name: /discover your next skills journey/i }),
+      await screen.findByRole('heading', { name: /course catalog/i }),
     ).toBeInTheDocument()
   })
 


### PR DESCRIPTION
## Summary

Two test assertions broke after the UI improvements in #112 were merged:

- **Course catalog heading:** The test expected the old hardcoded title `"Discover Your Next Skills Journey"`. Now that the org name is fetched dynamically, the fallback title is `"Course Catalog"` when no tenant data is loaded in tests.
- **Branding page logo alt text:** The test looked for `"Standard School current logo"`. The "Current public logo" block was removed and the logo is now inline beside the tenant card, so the alt text is now `"Standard School logo"`.

## Test plan

- [x] All 54 tests pass locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)